### PR TITLE
issue #26 fix proposal for apphdr json deserialization

### DIFF
--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/AbstractMX.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/AbstractMX.java
@@ -193,6 +193,7 @@ public abstract class AbstractMX extends AbstractMessage implements IDocument, J
         final Gson gson = new GsonBuilder()
                 .registerTypeAdapter(AbstractMX.class, new AbstractMXAdapter())
                 .registerTypeAdapter(XMLGregorianCalendar.class, new XMLGregorianCalendarAdapter())
+				.registerTypeAdapter(AppHdr.class, new AppHdrAdapter())
                 .create();
         return gson.fromJson(json, classOfT);
     }
@@ -208,6 +209,7 @@ public abstract class AbstractMX extends AbstractMessage implements IDocument, J
         final Gson gson = new GsonBuilder()
                 .registerTypeAdapter(AbstractMX.class, new AbstractMXAdapter())
                 .registerTypeAdapter(XMLGregorianCalendar.class, new XMLGregorianCalendarAdapter())
+				.registerTypeAdapter(AppHdr.class, new AppHdrAdapter())
                 .create();
         return gson.fromJson(json, AbstractMX.class);
     }
@@ -519,6 +521,7 @@ public abstract class AbstractMX extends AbstractMessage implements IDocument, J
         final Gson gson = new GsonBuilder()
                 .registerTypeAdapter(AbstractMX.class, new AbstractMXAdapter())
                 .registerTypeAdapter(XMLGregorianCalendar.class, new XMLGregorianCalendarAdapter())
+				.registerTypeAdapter(AppHdr.class, new AppHdrAdapter())
                 .setPrettyPrinting()
                 .create();
         // we use AbstractMX and not this.getClass() in order to force usage of the adapter

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/AppHdrAdapter.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/AppHdrAdapter.java
@@ -1,0 +1,40 @@
+package com.prowidesoftware.swift.model.mx;
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+
+public class AppHdrAdapter implements JsonSerializer<AppHdr>, JsonDeserializer<AppHdr> {
+
+    private static final String HDR_TYPE = "hdrType";
+
+    @Override
+    public JsonElement serialize(AppHdr hdr, Type typeOfSrc, JsonSerializationContext context) {
+        try {
+            String[] hdrType = hdr.getClass().getCanonicalName().split("[.]");
+            JsonObject json = context.serialize(hdr).getAsJsonObject();
+            json.addProperty(HDR_TYPE, hdrType[hdrType.length - 1]);
+            return json;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public AppHdr deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        try {
+            Class<?> type = LegacyAppHdr.class;
+            JsonElement identifier = json.getAsJsonObject().get(HDR_TYPE);
+            if (identifier != null) {
+                try {
+                    type = Class.forName("com.prowidesoftware.swift.model.mx." + identifier.getAsString());
+                } catch (ClassNotFoundException ignored) {}
+            }
+            return context.deserialize(json, type);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/AbstractMxJsonTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/AbstractMxJsonTest.java
@@ -15,6 +15,7 @@
  */
 package com.prowidesoftware.swift.model.mx;
 
+import com.prowidesoftware.swift.model.mx.dic.*;
 import org.junit.jupiter.api.Test;
 
 import javax.xml.datatype.DatatypeFactory;
@@ -39,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test for JSON conversion in the MX model (AbstractMX and subclasses).
- * * @since 7.10.2
+ * @since 7.10.2
  */
 public class AbstractMxJsonTest {
 

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/AbstractMxJsonTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/AbstractMxJsonTest.java
@@ -15,7 +15,6 @@
  */
 package com.prowidesoftware.swift.model.mx;
 
-import com.prowidesoftware.swift.model.mx.dic.*;
 import org.junit.jupiter.api.Test;
 
 import javax.xml.datatype.DatatypeFactory;
@@ -25,10 +24,22 @@ import java.util.GregorianCalendar;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.prowidesoftware.swift.model.mx.dic.AccountStatement6;
+import com.prowidesoftware.swift.model.mx.dic.BankToCustomerStatementV06;
+import com.prowidesoftware.swift.model.mx.dic.BranchAndFinancialInstitutionIdentification5;
+import com.prowidesoftware.swift.model.mx.dic.BranchData2;
+import com.prowidesoftware.swift.model.mx.dic.CashAccount25;
+import com.prowidesoftware.swift.model.mx.dic.CustomerCreditTransferInitiationV08;
+import com.prowidesoftware.swift.model.mx.dic.GroupHeader48;
+import com.prowidesoftware.swift.model.mx.dic.OrganisationIdentification8;
+import com.prowidesoftware.swift.model.mx.dic.Party11Choice;
+import com.prowidesoftware.swift.model.mx.dic.PartyIdentification43;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 /**
  * Test for JSON conversion in the MX model (AbstractMX and subclasses).
- *
- * @since 7.10.2
+ * * @since 7.10.2
  */
 public class AbstractMxJsonTest {
 
@@ -185,6 +196,101 @@ public class AbstractMxJsonTest {
         String json2 = mx2.toJson();
         assertEquals(mx, mx2);
         assertEquals(json, json2);
+    }
+
+    @Test
+    public void parseMxWithAppHdr() {
+        final String json = "{\n" +
+                "  \"fiCdtTrf\": {\n" +
+                "    \"grpHdr\": {\n" +
+                "      \"msgId\": \"A2P76703\",\n" +
+                "      \"creDtTm\": {\n" +
+                "        \"year\": 2021,\n" +
+                "        \"month\": 4,\n" +
+                "        \"day\": 28,\n" +
+                "        \"timezone\": 0,\n" +
+                "        \"hour\": 9,\n" +
+                "        \"minute\": 22,\n" +
+                "        \"second\": 56\n" +
+                "      },\n" +
+                "      \"nbOfTxs\": \"1\"\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"appHdr\": {\n" +
+                "    \"from\": {\n" +
+                "      \"type\": \"BIC\",\n" +
+                "      \"id\": \"ABNANL20606\"\n" +
+                "    },\n" +
+                "    \"to\": {\n" +
+                "      \"type\": \"BIC\",\n" +
+                "      \"id\": \"GIISIT2TXXX\"\n" +
+                "    },\n" +
+                "    \"msgName\": \"pacs.009.001.07\",\n" +
+                "    \"msgRef\": \"CPTE190421113270\",\n" +
+                "    \"crDate\": {\n" +
+                "      \"year\": 2021,\n" +
+                "      \"month\": 4,\n" +
+                "      \"day\": 28,\n" +
+                "      \"timezone\": 0,\n" +
+                "      \"hour\": 9,\n" +
+                "      \"minute\": 22,\n" +
+                "      \"second\": 56\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"type\": \"MX\",\n" +
+                "  \"@xmlns\": \"urn:iso:std:iso:20022:tech:xsd:pacs.009.001.07\",\n" +
+                "  \"identifier\": \"pacs.009.001.07\"\n" +
+                "}";
+        assertDoesNotThrow(() -> AbstractMX.fromJson(json));
+    }
+
+    @Test
+    public void parseSerializedMxWithAppHdr() {
+        final String json = "{\n" +
+                "  \"fiCdtTrf\": {\n" +
+                "    \"grpHdr\": {\n" +
+                "      \"msgId\": \"A2P76703\",\n" +
+                "      \"creDtTm\": {\n" +
+                "        \"year\": 2021,\n" +
+                "        \"month\": 4,\n" +
+                "        \"day\": 28,\n" +
+                "        \"timezone\": 0,\n" +
+                "        \"hour\": 9,\n" +
+                "        \"minute\": 22,\n" +
+                "        \"second\": 56\n" +
+                "      },\n" +
+                "      \"nbOfTxs\": \"1\"\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"appHdr\": {\n" +
+                "    \"from\": {\n" +
+                "      \"type\": \"BIC\",\n" +
+                "      \"id\": \"ABNANL20606\"\n" +
+                "    },\n" +
+                "    \"to\": {\n" +
+                "      \"type\": \"BIC\",\n" +
+                "      \"id\": \"GIISIT2TXXX\"\n" +
+                "    },\n" +
+                "    \"msgName\": \"pacs.009.001.07\",\n" +
+                "    \"msgRef\": \"CPTE190421113270\",\n" +
+                "    \"crDate\": {\n" +
+                "      \"year\": 2021,\n" +
+                "      \"month\": 4,\n" +
+                "      \"day\": 28,\n" +
+                "      \"timezone\": 0,\n" +
+                "      \"hour\": 9,\n" +
+                "      \"minute\": 22,\n" +
+                "      \"second\": 56\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"type\": \"MX\",\n" +
+                "  \"@xmlns\": \"urn:iso:std:iso:20022:tech:xsd:pacs.009.001.07\",\n" +
+                "  \"identifier\": \"pacs.009.001.07\"\n" +
+                "}";
+        AbstractMX source = AbstractMX.fromJson(json);
+        AbstractMX mx = AbstractMX.fromJson(source.toJson());
+        AbstractMX mx2 = AbstractMX.fromJson(mx.toJson());
+        assertEquals(mx, mx2);
     }
 
 }


### PR DESCRIPTION
Proposal of a fix for issue #26, adding a new Gson adapter for the AppHdr and a new `hdrType` field to store the AppHdr type in the serialized Json.

Defaults to LegacyAppHdr if the new type field is missing for compatibility