### PR TITLE
Fix for #45 - module java.xml does not opens X to unnamed module (Java 17)

### DIFF
--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/AbstractMX.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/AbstractMX.java
@@ -638,7 +638,7 @@ public abstract class AbstractMX extends AbstractMessage implements IDocument, J
     public String toJson() {
         final Gson gson = new GsonBuilder()
                 .registerTypeAdapter(AbstractMX.class, new AbstractMXAdapter())
-                .registerTypeAdapter(XMLGregorianCalendar.class, new XMLGregorianCalendarAdapter())
+                .registerTypeHierarchyAdapter(XMLGregorianCalendar.class, new XMLGregorianCalendarAdapter())
                 .registerTypeAdapter(AppHdr.class, new AppHdrAdapter())
                 .setPrettyPrinting()
                 .create();


### PR DESCRIPTION
## Original cause
Module java.xml does not "opens com.sun.org.apache.xerces.internal.jaxp.datatype" to unnamed module.

## Solution

Registering `XMLGregorianCalendarAdapter` as TypeHierarchyAdapter for `XMLGregorianCalendar` class

## Symptoms

The following exceptions appeared before the fix:
- (gson:2.8.9 — default) — `java.lang.reflect.InaccessibleObjectException`: Unable to make public com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl() accessible: module java.xml does not "exports com.sun.org.apache.xerces.internal.jaxp.datatype" to unnamed module
- (gson:2.9.0 — explicitly added dependency) — `com.google.gson.JsonIOException`: Failed making field 'com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl#eon' accessible; either change its visibility or write a custom TypeAdapter for its declaring type 
- (gson:2.9.0 — explicitly added dependency) — `java.lang.reflect.InaccessibleObjectException`: Unable to make field private java.math.BigInteger com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl.eon accessible: module java.xml does not "opens com.sun.org.apache.xerces.internal.jaxp.datatype" to unnamed module 

## Additional Info

No adding dependency for `javax.xml.bind:jaxb-api` and `com.sun.xml.bind:jaxb-impl` required to fix the mentioned problems.