### PR TITLE
Issue 118: Fix backward compatibility issue on DateTime fields (With fix and Javadoc)

### DIFF
--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/adapters/OffsetDateTimeJsonAdapter.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/adapters/OffsetDateTimeJsonAdapter.java
@@ -27,6 +27,9 @@ import java.util.logging.Logger;
 
 /**
  * This adapter enables accepting OffsetDateTime time Json format.
+ * <p> The adapter supports two DTO formats: the current one and the
+ * legacy one based on XMLGregorianCalendar model with Java 1.8.
+ * </p>
  *
  * @since 10.0.1
  */

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/adapters/OffsetDateTimeJsonAdapter.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/adapters/OffsetDateTimeJsonAdapter.java
@@ -16,7 +16,6 @@
 package com.prowidesoftware.swift.model.mx.adapters;
 
 import com.google.gson.*;
-
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -63,7 +62,10 @@ public class OffsetDateTimeJsonAdapter implements JsonSerializer<OffsetDateTime>
             // Parse DTO from current OffsetDateTime model
             return deserializeFromOffsetDateTimeDTO(gson.fromJson(jsonElement, DateTimeOffsetDTO.class));
         } catch (final Exception e) {
-            log.log(Level.FINEST, "Cannot parse JSON into OffsetDateTime from current DTO format: " + e.getMessage(), e);
+            log.log(
+                    Level.FINEST,
+                    "Cannot parse JSON into OffsetDateTime from current DTO format: " + e.getMessage(),
+                    e);
         }
         log.log(Level.FINEST, "Attempting parsing from legacy DTO format");
         try {
@@ -111,7 +113,8 @@ public class OffsetDateTimeJsonAdapter implements JsonSerializer<OffsetDateTime>
         return offsetDateTime;
     }
 
-    private OffsetDateTime deserializeFromXMLGregorianCalendarDTO(final XMLGregorianCalendarDTO xmlGregorianCalendarDTO) {
+    private OffsetDateTime deserializeFromXMLGregorianCalendarDTO(
+            final XMLGregorianCalendarDTO xmlGregorianCalendarDTO) {
         if (Integer.MIN_VALUE == xmlGregorianCalendarDTO.year) {
             xmlGregorianCalendarDTO.year = 0;
         }
@@ -134,21 +137,22 @@ public class OffsetDateTimeJsonAdapter implements JsonSerializer<OffsetDateTime>
             xmlGregorianCalendarDTO.timezone = null;
         }
 
-        return LocalDateTime
-                .of(
+        return LocalDateTime.of(
                         xmlGregorianCalendarDTO.year,
                         xmlGregorianCalendarDTO.month,
                         xmlGregorianCalendarDTO.day,
                         xmlGregorianCalendarDTO.hour,
                         xmlGregorianCalendarDTO.minute,
                         xmlGregorianCalendarDTO.second,
-                        xmlGregorianCalendarDTO.fractionalSecond.scaleByPowerOfTen(9).toBigInteger().intValueExact()
-                )
+                        xmlGregorianCalendarDTO
+                                .fractionalSecond
+                                .scaleByPowerOfTen(9)
+                                .toBigInteger()
+                                .intValueExact())
                 .atZone(
                         xmlGregorianCalendarDTO.timezone != null
                                 ? ZoneOffset.ofHours(xmlGregorianCalendarDTO.timezone)
-                                : ZoneOffset.systemDefault()
-                )
+                                : ZoneOffset.systemDefault())
                 .toOffsetDateTime();
     }
 
@@ -180,13 +184,13 @@ public class OffsetDateTimeJsonAdapter implements JsonSerializer<OffsetDateTime>
     }
 
     static class XMLGregorianCalendarDTO {
-        Integer     year;
-        Integer     month;
-        Integer     day;
-        Integer     hour = 0;
-        Integer     minute = 0;
-        Integer     second = 0;
-        BigDecimal  fractionalSecond = BigDecimal.ZERO;
-        Integer     timezone;
+        Integer year;
+        Integer month;
+        Integer day;
+        Integer hour = 0;
+        Integer minute = 0;
+        Integer second = 0;
+        BigDecimal fractionalSecond = BigDecimal.ZERO;
+        Integer timezone;
     }
 }

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/DateTimeJsonAdapterBackwardCompatibilityTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/DateTimeJsonAdapterBackwardCompatibilityTest.java
@@ -1,0 +1,549 @@
+package com.prowidesoftware.swift.model.mx.adapters;
+
+import com.prowidesoftware.swift.model.mx.AbstractMX;
+import com.prowidesoftware.swift.model.mx.MxSese02500109;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DateTimeJsonAdapterBackwardCompatibilityTest {
+  private static final String XML_MX = """
+    <?xml version="1.0"?>
+    <RequestPayload xmlns="urn:iso:std:iso:20022:tech:xsd:head.003.001.01">
+      <AppHdr xmlns="urn:iso:std:iso:20022:tech:xsd:head.001.001.01">
+        <Fr>
+          <FIId>
+            <FinInstnId>
+              <BICFI>IJKLMNOPXXX</BICFI>
+              <Othr>
+                <Id>ABCDEFGHXXX</Id>
+              </Othr>
+            </FinInstnId>
+          </FIId>
+        </Fr>
+        <To>
+          <FIId>
+            <FinInstnId>
+              <BICFI>ABCDEFGHXXX</BICFI>
+              <Othr>
+                <Id>ABCDEFGHXXX</Id>
+              </Othr>
+            </FinInstnId>
+          </FIId>
+        </To>
+        <BizMsgIdr>1423905641002</BizMsgIdr>
+        <MsgDefIdr>sese.025.001.09</MsgDefIdr>
+        <CreDt>2024-07-17T05:27:51Z</CreDt>
+        <CpyDplct>COPY</CpyDplct>
+        <PssblDplct>true</PssblDplct>
+        <Prty>2024071700000208</Prty>
+      </AppHdr>
+      <Document xmlns="urn:iso:std:iso:20022:tech:xsd:sese.025.001.09">
+        <SctiesSttlmTxConf>
+          <TxIdDtls>
+            <AcctOwnrTxId>FOO</AcctOwnrTxId>
+            <MktInfrstrctrTxId>BAR</MktInfrstrctrTxId>
+            <PrcrTxId>TOTO</PrcrTxId>
+            <SctiesMvmntTp>RECE</SctiesMvmntTp>
+            <Pmt>APMT</Pmt>
+            <CmonId>TITI</CmonId>
+          </TxIdDtls>
+          <TradDtls>
+            <PlcOfTrad>
+              <MktTpAndId>
+                <Tp>
+                  <Cd>EXCH</Cd>
+                </Tp>
+              </MktTpAndId>
+            </PlcOfTrad>
+            <PlcOfClr>
+              <Id>QRSTUVWYXXX</Id>
+            </PlcOfClr>
+            <TradDt>
+              <Dt>
+                <Dt>2024-07-16</Dt>
+              </Dt>
+            </TradDt>
+            <SttlmDt>
+              <Dt>
+                <Dt>2024-07-17</Dt>
+              </Dt>
+            </SttlmDt>
+            <FctvSttlmDt>
+              <Dt>
+                <DtTm>2024-07-17T07:26:04.207459</DtTm>
+              </Dt>
+            </FctvSttlmDt>
+          </TradDtls>
+          <FinInstrmId>
+            <ISIN>NL0000009165</ISIN>
+          </FinInstrmId>
+          <QtyAndAcctDtls>
+            <SttldQty>
+              <Qty>
+                <Unit>0</Unit>
+              </Qty>
+            </SttldQty>
+            <SfkpgAcct>
+              <Id>NECISOGEFRPPAGN000L10</Id>
+            </SfkpgAcct>
+            <CshAcct>
+              <Prtry>CFREURSOGEFRPPTIT-DCA-SGSS</Prtry>
+            </CshAcct>
+          </QtyAndAcctDtls>
+          <SttlmParams>
+            <SctiesTxTp>
+              <Cd>NETT</Cd>
+            </SctiesTxTp>
+            <PrtlSttlmInd>PARQ</PrtlSttlmInd>
+            <CshSubBalTp>
+              <Id>DLVR</Id>
+              <Issr>T2S</Issr>
+              <SchmeNm>RT</SchmeNm>
+            </CshSubBalTp>
+          </SttlmParams>
+          <DlvrgSttlmPties>
+            <Dpstry>
+              <Id>
+                <AnyBIC>ABCDEFGHXXX</AnyBIC>
+              </Id>
+              <PrcgId>2407162881091741</PrcgId>
+            </Dpstry>
+            <Pty1>
+              <Id>
+                <AnyBIC>QRSTUVWYXXX</AnyBIC>
+              </Id>
+              <SfkpgAcct>
+                <Id>MOTICCEGITRRXXX9100000</Id>
+              </SfkpgAcct>
+              <PrcgId>1VUVZK</PrcgId>
+            </Pty1>
+          </DlvrgSttlmPties>
+          <RcvgSttlmPties>
+            <Dpstry>
+              <Id>
+                <AnyBIC>HGFEDCBAXXX</AnyBIC>
+              </Id>
+            </Dpstry>
+            <Pty1>
+              <Id>
+                <AnyBIC>SOGEFRPPAGN</AnyBIC>
+              </Id>
+              <SfkpgAcct>
+                <Id>NECISOGEFRPPAGN000L10</Id>
+              </SfkpgAcct>
+              <PrcgId>FOO</PrcgId>
+            </Pty1>
+          </RcvgSttlmPties>
+          <SttldAmt>
+            <Amt Ccy="EUR">1</Amt>
+            <CdtDbtInd>DBIT</CdtDbtInd>
+          </SttldAmt>
+          <SplmtryData>
+            <PlcAndNm>/Document/SctiesSttlmTxConf/TxIdDtls</PlcAndNm>
+            <Envlp>
+              <Document xmlns="urn:eurosystem:xsd:DRAFT2supl.021.001.01">
+                <SctiesSttlmSD1>
+                  <RltdTxId>42</RltdTxId>
+                </SctiesSttlmSD1>
+              </Document>
+            </Envlp>
+          </SplmtryData>
+        </SctiesSttlmTxConf>
+      </Document>
+    </RequestPayload>
+    """;
+
+  private static final String JSON_MX_V9 = """
+    {
+      "sctiesSttlmTxConf": {
+        "txIdDtls": {
+          "acctOwnrTxId": "FOO",
+          "mktInfrstrctrTxId": "BAR",
+          "prcrTxId": "TOTO",
+          "sctiesMvmntTp": "RECE",
+          "pmt": "APMT",
+          "cmonId": "TITI"
+        },
+        "tradDtls": {
+          "plcOfTrad": {
+            "mktTpAndId": {
+              "tp": {
+                "cd": "EXCH"
+              }
+            }
+          },
+          "plcOfClr": {
+            "id": "QRSTUVWYXXX"
+          },
+          "tradDt": {
+            "dt": {
+              "dt": {
+                "year": 2024,
+                "month": 7,
+                "day": 16,
+                "timezone": -2147483648,
+                "hour": -2147483648,
+                "minute": -2147483648,
+                "second": -2147483648
+              }
+            }
+          },
+          "sttlmDt": {
+            "dt": {
+              "dt": {
+                "year": 2024,
+                "month": 7,
+                "day": 17,
+                "timezone": -2147483648,
+                "hour": -2147483648,
+                "minute": -2147483648,
+                "second": -2147483648
+              }
+            }
+          },
+          "fctvSttlmDt": {
+            "dt": {
+              "dtTm": {
+                "year": 2024,
+                "month": 7,
+                "day": 17,
+                "timezone": -2147483648,
+                "hour": 7,
+                "minute": 26,
+                "second": 4,
+                "fractionalSecond": 0.207459
+              }
+            }
+          }
+        },
+        "finInstrmId": {
+          "isin": "NL0000009165"
+        },
+        "qtyAndAcctDtls": {
+          "sttldQty": {
+            "qty": {
+              "unit": 0
+            }
+          },
+          "sfkpgAcct": {
+            "id": "NECISOGEFRPPAGN000L10"
+          },
+          "cshAcct": {
+            "prtry": "CFREURSOGEFRPPTIT-DCA-SGSS"
+          }
+        },
+        "sttlmParams": {
+          "sctiesTxTp": {
+            "cd": "NETT"
+          },
+          "prtlSttlmInd": "PARQ",
+          "cshSubBalTp": {
+            "id": "DLVR",
+            "issr": "T2S",
+            "schmeNm": "RT"
+          }
+        },
+        "dlvrgSttlmPties": {
+          "dpstry": {
+            "id": {
+              "anyBIC": "ABCDEFGHXXX"
+            },
+            "prcgId": "2407162881091741"
+          },
+          "pty1": {
+            "id": {
+              "anyBIC": "QRSTUVWYXXX"
+            },
+            "sfkpgAcct": {
+              "id": "MOTICCEGITRRXXX9100000"
+            },
+            "prcgId": "1VUVZK"
+          }
+        },
+        "rcvgSttlmPties": {
+          "dpstry": {
+            "id": {
+              "anyBIC": "HGFEDCBAXXX"
+            }
+          },
+          "pty1": {
+            "id": {
+              "anyBIC": "SOGEFRPPAGN"
+            },
+            "sfkpgAcct": {
+              "id": "NECISOGEFRPPAGN000L10"
+            },
+            "prcgId": "FOO"
+          }
+        },
+        "sttldAmt": {
+          "amt": {
+            "value": 1,
+            "ccy": "EUR"
+          },
+          "cdtDbtInd": "DBIT"
+        },
+        "splmtryData": [
+          {
+            "plcAndNm": "/Document/SctiesSttlmTxConf/TxIdDtls",
+            "envlp": {}
+          }
+        ]
+      },
+      "appHdr": {
+        "fr": {
+          "fiId": {
+            "finInstnId": {
+              "bicfi": "IJKLMNOPXXX",
+              "othr": {
+                "id": "ABCDEFGHXXX"
+              }
+            }
+          }
+        },
+        "to": {
+          "fiId": {
+            "finInstnId": {
+              "bicfi": "ABCDEFGHXXX",
+              "othr": {
+                "id": "ABCDEFGHXXX"
+              }
+            }
+          }
+        },
+        "bizMsgIdr": "1423905641002",
+        "msgDefIdr": "sese.025.001.09",
+        "creDt": {
+          "year": 2024,
+          "month": 7,
+          "day": 17,
+          "timezone": 0,
+          "hour": 5,
+          "minute": 27,
+          "second": 51
+        },
+        "cpyDplct": "COPY",
+        "pssblDplct": true,
+        "prty": "2024071700000208",
+        "namespace": "urn:iso:std:iso:20022:tech:xsd:head.001.001.01"
+      },
+      "type": "MX",
+      "@xmlns": "urn:iso:std:iso:20022:tech:xsd:sese.025.001.09",
+      "identifier": "sese.025.001.09"
+    }
+    """;
+
+  private static final String JSON_MX_V10 = """
+    {
+      "sctiesSttlmTxConf": {
+        "txIdDtls": {
+          "acctOwnrTxId": "FOO",
+          "mktInfrstrctrTxId": "BAR",
+          "prcrTxId": "TOTO",
+          "sctiesMvmntTp": "RECE",
+          "pmt": "APMT",
+          "cmonId": "TITI"
+        },
+        "tradDtls": {
+          "plcOfTrad": {
+            "mktTpAndId": {
+              "tp": {
+                "cd": "EXCH"
+              }
+            }
+          },
+          "plcOfClr": {
+            "id": "QRSTUVWYXXX"
+          },
+          "tradDt": {
+            "dt": {
+              "dt": {
+                "year": 2024,
+                "month": 7,
+                "day": 16
+              }
+            }
+          },
+          "sttlmDt": {
+            "dt": {
+              "dt": {
+                "year": 2024,
+                "month": 7,
+                "day": 17
+              }
+            }
+          },
+          "fctvSttlmDt": {
+            "dt": {
+              "dtTm": {
+                "dateTime": {
+                  "date": {
+                    "year": 2024,
+                    "month": 7,
+                    "day": 17
+                  },
+                  "time": {
+                    "hour": 7,
+                    "minute": 26,
+                    "second": 4,
+                    "nano": 207459000
+                  }
+                },
+                "offset": {
+                  "totalSeconds": 7200
+                }
+              }
+            }
+          }
+        },
+        "finInstrmId": {
+          "isin": "NL0000009165"
+        },
+        "qtyAndAcctDtls": {
+          "sttldQty": {
+            "qty": {
+              "unit": 0
+            }
+          },
+          "sfkpgAcct": {
+            "id": "NECISOGEFRPPAGN000L10"
+          },
+          "cshAcct": {
+            "prtry": "CFREURSOGEFRPPTIT-DCA-SGSS"
+          }
+        },
+        "sttlmParams": {
+          "sctiesTxTp": {
+            "cd": "NETT"
+          },
+          "prtlSttlmInd": "PARQ",
+          "cshSubBalTp": {
+            "id": "DLVR",
+            "issr": "T2S",
+            "schmeNm": "RT"
+          }
+        },
+        "dlvrgSttlmPties": {
+          "dpstry": {
+            "id": {
+              "anyBIC": "ABCDEFGHXXX"
+            },
+            "prcgId": "2407162881091741"
+          },
+          "pty1": {
+            "id": {
+              "anyBIC": "QRSTUVWYXXX"
+            },
+            "sfkpgAcct": {
+              "id": "MOTICCEGITRRXXX9100000"
+            },
+            "prcgId": "1VUVZK"
+          }
+        },
+        "rcvgSttlmPties": {
+          "dpstry": {
+            "id": {
+              "anyBIC": "HGFEDCBAXXX"
+            }
+          },
+          "pty1": {
+            "id": {
+              "anyBIC": "SOGEFRPPAGN"
+            },
+            "sfkpgAcct": {
+              "id": "NECISOGEFRPPAGN000L10"
+            },
+            "prcgId": "FOO"
+          }
+        },
+        "sttldAmt": {
+          "amt": {
+            "value": 1,
+            "ccy": "EUR"
+          },
+          "cdtDbtInd": "DBIT"
+        },
+        "splmtryData": [
+          {
+            "plcAndNm": "/Document/SctiesSttlmTxConf/TxIdDtls",
+            "envlp": {}
+          }
+        ]
+      },
+      "appHdr": {
+        "fr": {
+          "fiId": {
+            "finInstnId": {
+              "bicfi": "IJKLMNOPXXX",
+              "othr": {
+                "id": "ABCDEFGHXXX"
+              }
+            }
+          }
+        },
+        "to": {
+          "fiId": {
+            "finInstnId": {
+              "bicfi": "ABCDEFGHXXX",
+              "othr": {
+                "id": "ABCDEFGHXXX"
+              }
+            }
+          }
+        },
+        "bizMsgIdr": "1423905641002",
+        "msgDefIdr": "sese.025.001.09",
+        "creDt": {
+          "dateTime": {
+            "date": {
+              "year": 2024,
+              "month": 7,
+              "day": 17
+            },
+            "time": {
+              "hour": 5,
+              "minute": 27,
+              "second": 51,
+              "nano": 0
+            }
+          },
+          "offset": {
+            "totalSeconds": 0
+          }
+        },
+        "cpyDplct": "COPY",
+        "pssblDplct": true,
+        "prty": "2024071700000208",
+        "namespace": "urn:iso:std:iso:20022:tech:xsd:head.001.001.01"
+      },
+      "type": "MX",
+      "@xmlns": "urn:iso:std:iso:20022:tech:xsd:sese.025.001.09",
+      "identifier": "sese.025.001.09"
+    }
+    """;
+
+  @Test
+  void v10_should_be_able_to_parse_json_with_date_time_created_from_v9() {
+    final MxSese02500109 mx = (MxSese02500109) AbstractMX.fromJson(JSON_MX_V9);
+    assertThat(mx.getSctiesSttlmTxConf().getTradDtls().getTradDt().getDt().getDt()).isNotNull(); // Success
+    assertThat(mx.getSctiesSttlmTxConf().getTradDtls().getFctvSttlmDt().getDt().getDtTm()).isNotNull(); // Fail
+  }
+
+  @Test
+  void v10_should_be_able_to_parse_json_from_v9_and_read_same_content_than_json_from_v10_and_xml() {
+    final MxSese02500109 reference  = (MxSese02500109) AbstractMX.parse(XML_MX);
+    final MxSese02500109 fromV9     = (MxSese02500109) AbstractMX.fromJson(JSON_MX_V9);
+    final String         toV10      = reference.toJson();
+    final MxSese02500109 fromV10    = (MxSese02500109) AbstractMX.fromJson(JSON_MX_V10);
+
+    assertThat(fromV9).isEqualTo(reference);
+    assertThat(fromV10).isEqualTo(reference);
+    assertThat(fromV9).isEqualTo(fromV10);
+    assertThat(toV10).isEqualToIgnoringWhitespace(JSON_MX_V10);
+    assertThat(toV10).isNotEqualToIgnoringWhitespace(JSON_MX_V9);
+  }
+}

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/DateTimeJsonAdapterBackwardCompatibilityTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/DateTimeJsonAdapterBackwardCompatibilityTest.java
@@ -1,549 +1,547 @@
 package com.prowidesoftware.swift.model.mx.adapters;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.prowidesoftware.swift.model.mx.AbstractMX;
 import com.prowidesoftware.swift.model.mx.MxSese02500109;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class DateTimeJsonAdapterBackwardCompatibilityTest {
-  private static final String XML_MX = """
-    <?xml version="1.0"?>
-    <RequestPayload xmlns="urn:iso:std:iso:20022:tech:xsd:head.003.001.01">
-      <AppHdr xmlns="urn:iso:std:iso:20022:tech:xsd:head.001.001.01">
-        <Fr>
-          <FIId>
-            <FinInstnId>
-              <BICFI>IJKLMNOPXXX</BICFI>
-              <Othr>
-                <Id>ABCDEFGHXXX</Id>
-              </Othr>
-            </FinInstnId>
-          </FIId>
-        </Fr>
-        <To>
-          <FIId>
-            <FinInstnId>
-              <BICFI>ABCDEFGHXXX</BICFI>
-              <Othr>
-                <Id>ABCDEFGHXXX</Id>
-              </Othr>
-            </FinInstnId>
-          </FIId>
-        </To>
-        <BizMsgIdr>1423905641002</BizMsgIdr>
-        <MsgDefIdr>sese.025.001.09</MsgDefIdr>
-        <CreDt>2024-07-17T05:27:51Z</CreDt>
-        <CpyDplct>COPY</CpyDplct>
-        <PssblDplct>true</PssblDplct>
-        <Prty>2024071700000208</Prty>
-      </AppHdr>
-      <Document xmlns="urn:iso:std:iso:20022:tech:xsd:sese.025.001.09">
-        <SctiesSttlmTxConf>
-          <TxIdDtls>
-            <AcctOwnrTxId>FOO</AcctOwnrTxId>
-            <MktInfrstrctrTxId>BAR</MktInfrstrctrTxId>
-            <PrcrTxId>TOTO</PrcrTxId>
-            <SctiesMvmntTp>RECE</SctiesMvmntTp>
-            <Pmt>APMT</Pmt>
-            <CmonId>TITI</CmonId>
-          </TxIdDtls>
-          <TradDtls>
-            <PlcOfTrad>
-              <MktTpAndId>
-                <Tp>
-                  <Cd>EXCH</Cd>
-                </Tp>
-              </MktTpAndId>
-            </PlcOfTrad>
-            <PlcOfClr>
-              <Id>QRSTUVWYXXX</Id>
-            </PlcOfClr>
-            <TradDt>
-              <Dt>
-                <Dt>2024-07-16</Dt>
-              </Dt>
-            </TradDt>
-            <SttlmDt>
-              <Dt>
-                <Dt>2024-07-17</Dt>
-              </Dt>
-            </SttlmDt>
-            <FctvSttlmDt>
-              <Dt>
-                <DtTm>2024-07-17T07:26:04.207459</DtTm>
-              </Dt>
-            </FctvSttlmDt>
-          </TradDtls>
-          <FinInstrmId>
-            <ISIN>NL0000009165</ISIN>
-          </FinInstrmId>
-          <QtyAndAcctDtls>
-            <SttldQty>
-              <Qty>
-                <Unit>0</Unit>
-              </Qty>
-            </SttldQty>
-            <SfkpgAcct>
-              <Id>NECISOGEFRPPAGN000L10</Id>
-            </SfkpgAcct>
-            <CshAcct>
-              <Prtry>CFREURSOGEFRPPTIT-DCA-SGSS</Prtry>
-            </CshAcct>
-          </QtyAndAcctDtls>
-          <SttlmParams>
-            <SctiesTxTp>
-              <Cd>NETT</Cd>
-            </SctiesTxTp>
-            <PrtlSttlmInd>PARQ</PrtlSttlmInd>
-            <CshSubBalTp>
-              <Id>DLVR</Id>
-              <Issr>T2S</Issr>
-              <SchmeNm>RT</SchmeNm>
-            </CshSubBalTp>
-          </SttlmParams>
-          <DlvrgSttlmPties>
-            <Dpstry>
-              <Id>
-                <AnyBIC>ABCDEFGHXXX</AnyBIC>
-              </Id>
-              <PrcgId>2407162881091741</PrcgId>
-            </Dpstry>
-            <Pty1>
-              <Id>
-                <AnyBIC>QRSTUVWYXXX</AnyBIC>
-              </Id>
-              <SfkpgAcct>
-                <Id>MOTICCEGITRRXXX9100000</Id>
-              </SfkpgAcct>
-              <PrcgId>1VUVZK</PrcgId>
-            </Pty1>
-          </DlvrgSttlmPties>
-          <RcvgSttlmPties>
-            <Dpstry>
-              <Id>
-                <AnyBIC>HGFEDCBAXXX</AnyBIC>
-              </Id>
-            </Dpstry>
-            <Pty1>
-              <Id>
-                <AnyBIC>SOGEFRPPAGN</AnyBIC>
-              </Id>
-              <SfkpgAcct>
-                <Id>NECISOGEFRPPAGN000L10</Id>
-              </SfkpgAcct>
-              <PrcgId>FOO</PrcgId>
-            </Pty1>
-          </RcvgSttlmPties>
-          <SttldAmt>
-            <Amt Ccy="EUR">1</Amt>
-            <CdtDbtInd>DBIT</CdtDbtInd>
-          </SttldAmt>
-          <SplmtryData>
-            <PlcAndNm>/Document/SctiesSttlmTxConf/TxIdDtls</PlcAndNm>
-            <Envlp>
-              <Document xmlns="urn:eurosystem:xsd:DRAFT2supl.021.001.01">
-                <SctiesSttlmSD1>
-                  <RltdTxId>42</RltdTxId>
-                </SctiesSttlmSD1>
-              </Document>
-            </Envlp>
-          </SplmtryData>
-        </SctiesSttlmTxConf>
-      </Document>
-    </RequestPayload>
-    """;
+    private static final String XML_MX = "<?xml version=\"1.0\"?>\n"
+            + "    <RequestPayload xmlns=\"urn:iso:std:iso:20022:tech:xsd:head.003.001.01\">\n"
+            + "      <AppHdr xmlns=\"urn:iso:std:iso:20022:tech:xsd:head.001.001.01\">\n"
+            + "        <Fr>\n"
+            + "          <FIId>\n"
+            + "            <FinInstnId>\n"
+            + "              <BICFI>IJKLMNOPXXX</BICFI>\n"
+            + "              <Othr>\n"
+            + "                <Id>ABCDEFGHXXX</Id>\n"
+            + "              </Othr>\n"
+            + "            </FinInstnId>\n"
+            + "          </FIId>\n"
+            + "        </Fr>\n"
+            + "        <To>\n"
+            + "          <FIId>\n"
+            + "            <FinInstnId>\n"
+            + "              <BICFI>ABCDEFGHXXX</BICFI>\n"
+            + "              <Othr>\n"
+            + "                <Id>ABCDEFGHXXX</Id>\n"
+            + "              </Othr>\n"
+            + "            </FinInstnId>\n"
+            + "          </FIId>\n"
+            + "        </To>\n"
+            + "        <BizMsgIdr>1423905641002</BizMsgIdr>\n"
+            + "        <MsgDefIdr>sese.025.001.09</MsgDefIdr>\n"
+            + "        <CreDt>2024-07-17T05:27:51Z</CreDt>\n"
+            + "        <CpyDplct>COPY</CpyDplct>\n"
+            + "        <PssblDplct>true</PssblDplct>\n"
+            + "        <Prty>2024071700000208</Prty>\n"
+            + "      </AppHdr>\n"
+            + "      <Document xmlns=\"urn:iso:std:iso:20022:tech:xsd:sese.025.001.09\">\n"
+            + "        <SctiesSttlmTxConf>\n"
+            + "          <TxIdDtls>\n"
+            + "            <AcctOwnrTxId>FOO</AcctOwnrTxId>\n"
+            + "            <MktInfrstrctrTxId>BAR</MktInfrstrctrTxId>\n"
+            + "            <PrcrTxId>TOTO</PrcrTxId>\n"
+            + "            <SctiesMvmntTp>RECE</SctiesMvmntTp>\n"
+            + "            <Pmt>APMT</Pmt>\n"
+            + "            <CmonId>TITI</CmonId>\n"
+            + "          </TxIdDtls>\n"
+            + "          <TradDtls>\n"
+            + "            <PlcOfTrad>\n"
+            + "              <MktTpAndId>\n"
+            + "                <Tp>\n"
+            + "                  <Cd>EXCH</Cd>\n"
+            + "                </Tp>\n"
+            + "              </MktTpAndId>\n"
+            + "            </PlcOfTrad>\n"
+            + "            <PlcOfClr>\n"
+            + "              <Id>QRSTUVWYXXX</Id>\n"
+            + "            </PlcOfClr>\n"
+            + "            <TradDt>\n"
+            + "              <Dt>\n"
+            + "                <Dt>2024-07-16</Dt>\n"
+            + "              </Dt>\n"
+            + "            </TradDt>\n"
+            + "            <SttlmDt>\n"
+            + "              <Dt>\n"
+            + "                <Dt>2024-07-17</Dt>\n"
+            + "              </Dt>\n"
+            + "            </SttlmDt>\n"
+            + "            <FctvSttlmDt>\n"
+            + "              <Dt>\n"
+            + "                <DtTm>2024-07-17T07:26:04.207459</DtTm>\n"
+            + "              </Dt>\n"
+            + "            </FctvSttlmDt>\n"
+            + "          </TradDtls>\n"
+            + "          <FinInstrmId>\n"
+            + "            <ISIN>NL0000009165</ISIN>\n"
+            + "          </FinInstrmId>\n"
+            + "          <QtyAndAcctDtls>\n"
+            + "            <SttldQty>\n"
+            + "              <Qty>\n"
+            + "                <Unit>0</Unit>\n"
+            + "              </Qty>\n"
+            + "            </SttldQty>\n"
+            + "            <SfkpgAcct>\n"
+            + "              <Id>NECISOGEFRPPAGN000L10</Id>\n"
+            + "            </SfkpgAcct>\n"
+            + "            <CshAcct>\n"
+            + "              <Prtry>CFREURSOGEFRPPTIT-DCA-SGSS</Prtry>\n"
+            + "            </CshAcct>\n"
+            + "          </QtyAndAcctDtls>\n"
+            + "          <SttlmParams>\n"
+            + "            <SctiesTxTp>\n"
+            + "              <Cd>NETT</Cd>\n"
+            + "            </SctiesTxTp>\n"
+            + "            <PrtlSttlmInd>PARQ</PrtlSttlmInd>\n"
+            + "            <CshSubBalTp>\n"
+            + "              <Id>DLVR</Id>\n"
+            + "              <Issr>T2S</Issr>\n"
+            + "              <SchmeNm>RT</SchmeNm>\n"
+            + "            </CshSubBalTp>\n"
+            + "          </SttlmParams>\n"
+            + "          <DlvrgSttlmPties>\n"
+            + "            <Dpstry>\n"
+            + "              <Id>\n"
+            + "                <AnyBIC>ABCDEFGHXXX</AnyBIC>\n"
+            + "              </Id>\n"
+            + "              <PrcgId>2407162881091741</PrcgId>\n"
+            + "            </Dpstry>\n"
+            + "            <Pty1>\n"
+            + "              <Id>\n"
+            + "                <AnyBIC>QRSTUVWYXXX</AnyBIC>\n"
+            + "              </Id>\n"
+            + "              <SfkpgAcct>\n"
+            + "                <Id>MOTICCEGITRRXXX9100000</Id>\n"
+            + "              </SfkpgAcct>\n"
+            + "              <PrcgId>1VUVZK</PrcgId>\n"
+            + "            </Pty1>\n"
+            + "          </DlvrgSttlmPties>\n"
+            + "          <RcvgSttlmPties>\n"
+            + "            <Dpstry>\n"
+            + "              <Id>\n"
+            + "                <AnyBIC>HGFEDCBAXXX</AnyBIC>\n"
+            + "              </Id>\n"
+            + "            </Dpstry>\n"
+            + "            <Pty1>\n"
+            + "              <Id>\n"
+            + "                <AnyBIC>SOGEFRPPAGN</AnyBIC>\n"
+            + "              </Id>\n"
+            + "              <SfkpgAcct>\n"
+            + "                <Id>NECISOGEFRPPAGN000L10</Id>\n"
+            + "              </SfkpgAcct>\n"
+            + "              <PrcgId>FOO</PrcgId>\n"
+            + "            </Pty1>\n"
+            + "          </RcvgSttlmPties>\n"
+            + "          <SttldAmt>\n"
+            + "            <Amt Ccy=\"EUR\">1</Amt>\n"
+            + "            <CdtDbtInd>DBIT</CdtDbtInd>\n"
+            + "          </SttldAmt>\n"
+            + "          <SplmtryData>\n"
+            + "            <PlcAndNm>/Document/SctiesSttlmTxConf/TxIdDtls</PlcAndNm>\n"
+            + "            <Envlp>\n"
+            + "              <Document xmlns=\"urn:eurosystem:xsd:DRAFT2supl.021.001.01\">\n"
+            + "                <SctiesSttlmSD1>\n"
+            + "                  <RltdTxId>42</RltdTxId>\n"
+            + "                </SctiesSttlmSD1>\n"
+            + "              </Document>\n"
+            + "            </Envlp>\n"
+            + "          </SplmtryData>\n"
+            + "        </SctiesSttlmTxConf>\n"
+            + "      </Document>\n"
+            + "    </RequestPayload>";
 
-  private static final String JSON_MX_V9 = """
-    {
-      "sctiesSttlmTxConf": {
-        "txIdDtls": {
-          "acctOwnrTxId": "FOO",
-          "mktInfrstrctrTxId": "BAR",
-          "prcrTxId": "TOTO",
-          "sctiesMvmntTp": "RECE",
-          "pmt": "APMT",
-          "cmonId": "TITI"
-        },
-        "tradDtls": {
-          "plcOfTrad": {
-            "mktTpAndId": {
-              "tp": {
-                "cd": "EXCH"
-              }
-            }
-          },
-          "plcOfClr": {
-            "id": "QRSTUVWYXXX"
-          },
-          "tradDt": {
-            "dt": {
-              "dt": {
-                "year": 2024,
-                "month": 7,
-                "day": 16,
-                "timezone": -2147483648,
-                "hour": -2147483648,
-                "minute": -2147483648,
-                "second": -2147483648
-              }
-            }
-          },
-          "sttlmDt": {
-            "dt": {
-              "dt": {
-                "year": 2024,
-                "month": 7,
-                "day": 17,
-                "timezone": -2147483648,
-                "hour": -2147483648,
-                "minute": -2147483648,
-                "second": -2147483648
-              }
-            }
-          },
-          "fctvSttlmDt": {
-            "dt": {
-              "dtTm": {
-                "year": 2024,
-                "month": 7,
-                "day": 17,
-                "timezone": -2147483648,
-                "hour": 7,
-                "minute": 26,
-                "second": 4,
-                "fractionalSecond": 0.207459
-              }
-            }
-          }
-        },
-        "finInstrmId": {
-          "isin": "NL0000009165"
-        },
-        "qtyAndAcctDtls": {
-          "sttldQty": {
-            "qty": {
-              "unit": 0
-            }
-          },
-          "sfkpgAcct": {
-            "id": "NECISOGEFRPPAGN000L10"
-          },
-          "cshAcct": {
-            "prtry": "CFREURSOGEFRPPTIT-DCA-SGSS"
-          }
-        },
-        "sttlmParams": {
-          "sctiesTxTp": {
-            "cd": "NETT"
-          },
-          "prtlSttlmInd": "PARQ",
-          "cshSubBalTp": {
-            "id": "DLVR",
-            "issr": "T2S",
-            "schmeNm": "RT"
-          }
-        },
-        "dlvrgSttlmPties": {
-          "dpstry": {
-            "id": {
-              "anyBIC": "ABCDEFGHXXX"
-            },
-            "prcgId": "2407162881091741"
-          },
-          "pty1": {
-            "id": {
-              "anyBIC": "QRSTUVWYXXX"
-            },
-            "sfkpgAcct": {
-              "id": "MOTICCEGITRRXXX9100000"
-            },
-            "prcgId": "1VUVZK"
-          }
-        },
-        "rcvgSttlmPties": {
-          "dpstry": {
-            "id": {
-              "anyBIC": "HGFEDCBAXXX"
-            }
-          },
-          "pty1": {
-            "id": {
-              "anyBIC": "SOGEFRPPAGN"
-            },
-            "sfkpgAcct": {
-              "id": "NECISOGEFRPPAGN000L10"
-            },
-            "prcgId": "FOO"
-          }
-        },
-        "sttldAmt": {
-          "amt": {
-            "value": 1,
-            "ccy": "EUR"
-          },
-          "cdtDbtInd": "DBIT"
-        },
-        "splmtryData": [
-          {
-            "plcAndNm": "/Document/SctiesSttlmTxConf/TxIdDtls",
-            "envlp": {}
-          }
-        ]
-      },
-      "appHdr": {
-        "fr": {
-          "fiId": {
-            "finInstnId": {
-              "bicfi": "IJKLMNOPXXX",
-              "othr": {
-                "id": "ABCDEFGHXXX"
-              }
-            }
-          }
-        },
-        "to": {
-          "fiId": {
-            "finInstnId": {
-              "bicfi": "ABCDEFGHXXX",
-              "othr": {
-                "id": "ABCDEFGHXXX"
-              }
-            }
-          }
-        },
-        "bizMsgIdr": "1423905641002",
-        "msgDefIdr": "sese.025.001.09",
-        "creDt": {
-          "year": 2024,
-          "month": 7,
-          "day": 17,
-          "timezone": 0,
-          "hour": 5,
-          "minute": 27,
-          "second": 51
-        },
-        "cpyDplct": "COPY",
-        "pssblDplct": true,
-        "prty": "2024071700000208",
-        "namespace": "urn:iso:std:iso:20022:tech:xsd:head.001.001.01"
-      },
-      "type": "MX",
-      "@xmlns": "urn:iso:std:iso:20022:tech:xsd:sese.025.001.09",
-      "identifier": "sese.025.001.09"
+    private static final String JSON_MX_V9 = "{\n" + "      \"sctiesSttlmTxConf\": {\n"
+            + "        \"txIdDtls\": {\n"
+            + "          \"acctOwnrTxId\": \"FOO\",\n"
+            + "          \"mktInfrstrctrTxId\": \"BAR\",\n"
+            + "          \"prcrTxId\": \"TOTO\",\n"
+            + "          \"sctiesMvmntTp\": \"RECE\",\n"
+            + "          \"pmt\": \"APMT\",\n"
+            + "          \"cmonId\": \"TITI\"\n"
+            + "        },\n"
+            + "        \"tradDtls\": {\n"
+            + "          \"plcOfTrad\": {\n"
+            + "            \"mktTpAndId\": {\n"
+            + "              \"tp\": {\n"
+            + "                \"cd\": \"EXCH\"\n"
+            + "              }\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"plcOfClr\": {\n"
+            + "            \"id\": \"QRSTUVWYXXX\"\n"
+            + "          },\n"
+            + "          \"tradDt\": {\n"
+            + "            \"dt\": {\n"
+            + "              \"dt\": {\n"
+            + "                \"year\": 2024,\n"
+            + "                \"month\": 7,\n"
+            + "                \"day\": 16,\n"
+            + "                \"timezone\": -2147483648,\n"
+            + "                \"hour\": -2147483648,\n"
+            + "                \"minute\": -2147483648,\n"
+            + "                \"second\": -2147483648\n"
+            + "              }\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"sttlmDt\": {\n"
+            + "            \"dt\": {\n"
+            + "              \"dt\": {\n"
+            + "                \"year\": 2024,\n"
+            + "                \"month\": 7,\n"
+            + "                \"day\": 17,\n"
+            + "                \"timezone\": -2147483648,\n"
+            + "                \"hour\": -2147483648,\n"
+            + "                \"minute\": -2147483648,\n"
+            + "                \"second\": -2147483648\n"
+            + "              }\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"fctvSttlmDt\": {\n"
+            + "            \"dt\": {\n"
+            + "              \"dtTm\": {\n"
+            + "                \"year\": 2024,\n"
+            + "                \"month\": 7,\n"
+            + "                \"day\": 17,\n"
+            + "                \"timezone\": -2147483648,\n"
+            + "                \"hour\": 7,\n"
+            + "                \"minute\": 26,\n"
+            + "                \"second\": 4,\n"
+            + "                \"fractionalSecond\": 0.207459\n"
+            + "              }\n"
+            + "            }\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"finInstrmId\": {\n"
+            + "          \"isin\": \"NL0000009165\"\n"
+            + "        },\n"
+            + "        \"qtyAndAcctDtls\": {\n"
+            + "          \"sttldQty\": {\n"
+            + "            \"qty\": {\n"
+            + "              \"unit\": 0\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"sfkpgAcct\": {\n"
+            + "            \"id\": \"NECISOGEFRPPAGN000L10\"\n"
+            + "          },\n"
+            + "          \"cshAcct\": {\n"
+            + "            \"prtry\": \"CFREURSOGEFRPPTIT-DCA-SGSS\"\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"sttlmParams\": {\n"
+            + "          \"sctiesTxTp\": {\n"
+            + "            \"cd\": \"NETT\"\n"
+            + "          },\n"
+            + "          \"prtlSttlmInd\": \"PARQ\",\n"
+            + "          \"cshSubBalTp\": {\n"
+            + "            \"id\": \"DLVR\",\n"
+            + "            \"issr\": \"T2S\",\n"
+            + "            \"schmeNm\": \"RT\"\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"dlvrgSttlmPties\": {\n"
+            + "          \"dpstry\": {\n"
+            + "            \"id\": {\n"
+            + "              \"anyBIC\": \"ABCDEFGHXXX\"\n"
+            + "            },\n"
+            + "            \"prcgId\": \"2407162881091741\"\n"
+            + "          },\n"
+            + "          \"pty1\": {\n"
+            + "            \"id\": {\n"
+            + "              \"anyBIC\": \"QRSTUVWYXXX\"\n"
+            + "            },\n"
+            + "            \"sfkpgAcct\": {\n"
+            + "              \"id\": \"MOTICCEGITRRXXX9100000\"\n"
+            + "            },\n"
+            + "            \"prcgId\": \"1VUVZK\"\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"rcvgSttlmPties\": {\n"
+            + "          \"dpstry\": {\n"
+            + "            \"id\": {\n"
+            + "              \"anyBIC\": \"HGFEDCBAXXX\"\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"pty1\": {\n"
+            + "            \"id\": {\n"
+            + "              \"anyBIC\": \"SOGEFRPPAGN\"\n"
+            + "            },\n"
+            + "            \"sfkpgAcct\": {\n"
+            + "              \"id\": \"NECISOGEFRPPAGN000L10\"\n"
+            + "            },\n"
+            + "            \"prcgId\": \"FOO\"\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"sttldAmt\": {\n"
+            + "          \"amt\": {\n"
+            + "            \"value\": 1,\n"
+            + "            \"ccy\": \"EUR\"\n"
+            + "          },\n"
+            + "          \"cdtDbtInd\": \"DBIT\"\n"
+            + "        },\n"
+            + "        \"splmtryData\": [\n"
+            + "          {\n"
+            + "            \"plcAndNm\": \"/Document/SctiesSttlmTxConf/TxIdDtls\",\n"
+            + "            \"envlp\": {}\n"
+            + "          }\n"
+            + "        ]\n"
+            + "      },\n"
+            + "      \"appHdr\": {\n"
+            + "        \"fr\": {\n"
+            + "          \"fiId\": {\n"
+            + "            \"finInstnId\": {\n"
+            + "              \"bicfi\": \"IJKLMNOPXXX\",\n"
+            + "              \"othr\": {\n"
+            + "                \"id\": \"ABCDEFGHXXX\"\n"
+            + "              }\n"
+            + "            }\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"to\": {\n"
+            + "          \"fiId\": {\n"
+            + "            \"finInstnId\": {\n"
+            + "              \"bicfi\": \"ABCDEFGHXXX\",\n"
+            + "              \"othr\": {\n"
+            + "                \"id\": \"ABCDEFGHXXX\"\n"
+            + "              }\n"
+            + "            }\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"bizMsgIdr\": \"1423905641002\",\n"
+            + "        \"msgDefIdr\": \"sese.025.001.09\",\n"
+            + "        \"creDt\": {\n"
+            + "          \"year\": 2024,\n"
+            + "          \"month\": 7,\n"
+            + "          \"day\": 17,\n"
+            + "          \"timezone\": 0,\n"
+            + "          \"hour\": 5,\n"
+            + "          \"minute\": 27,\n"
+            + "          \"second\": 51\n"
+            + "        },\n"
+            + "        \"cpyDplct\": \"COPY\",\n"
+            + "        \"pssblDplct\": true,\n"
+            + "        \"prty\": \"2024071700000208\",\n"
+            + "        \"namespace\": \"urn:iso:std:iso:20022:tech:xsd:head.001.001.01\"\n"
+            + "      },\n"
+            + "      \"type\": \"MX\",\n"
+            + "      \"@xmlns\": \"urn:iso:std:iso:20022:tech:xsd:sese.025.001.09\",\n"
+            + "      \"identifier\": \"sese.025.001.09\"\n"
+            + "    }";
+
+    private static final String JSON_MX_V10 = "{\n" + "      \"sctiesSttlmTxConf\": {\n"
+            + "        \"txIdDtls\": {\n"
+            + "          \"acctOwnrTxId\": \"FOO\",\n"
+            + "          \"mktInfrstrctrTxId\": \"BAR\",\n"
+            + "          \"prcrTxId\": \"TOTO\",\n"
+            + "          \"sctiesMvmntTp\": \"RECE\",\n"
+            + "          \"pmt\": \"APMT\",\n"
+            + "          \"cmonId\": \"TITI\"\n"
+            + "        },\n"
+            + "        \"tradDtls\": {\n"
+            + "          \"plcOfTrad\": {\n"
+            + "            \"mktTpAndId\": {\n"
+            + "              \"tp\": {\n"
+            + "                \"cd\": \"EXCH\"\n"
+            + "              }\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"plcOfClr\": {\n"
+            + "            \"id\": \"QRSTUVWYXXX\"\n"
+            + "          },\n"
+            + "          \"tradDt\": {\n"
+            + "            \"dt\": {\n"
+            + "              \"dt\": {\n"
+            + "                \"year\": 2024,\n"
+            + "                \"month\": 7,\n"
+            + "                \"day\": 16\n"
+            + "              }\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"sttlmDt\": {\n"
+            + "            \"dt\": {\n"
+            + "              \"dt\": {\n"
+            + "                \"year\": 2024,\n"
+            + "                \"month\": 7,\n"
+            + "                \"day\": 17\n"
+            + "              }\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"fctvSttlmDt\": {\n"
+            + "            \"dt\": {\n"
+            + "              \"dtTm\": {\n"
+            + "                \"dateTime\": {\n"
+            + "                  \"date\": {\n"
+            + "                    \"year\": 2024,\n"
+            + "                    \"month\": 7,\n"
+            + "                    \"day\": 17\n"
+            + "                  },\n"
+            + "                  \"time\": {\n"
+            + "                    \"hour\": 7,\n"
+            + "                    \"minute\": 26,\n"
+            + "                    \"second\": 4,\n"
+            + "                    \"nano\": 207459000\n"
+            + "                  }\n"
+            + "                },\n"
+            + "                \"offset\": {\n"
+            + "                  \"totalSeconds\": 7200\n"
+            + "                }\n"
+            + "              }\n"
+            + "            }\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"finInstrmId\": {\n"
+            + "          \"isin\": \"NL0000009165\"\n"
+            + "        },\n"
+            + "        \"qtyAndAcctDtls\": {\n"
+            + "          \"sttldQty\": {\n"
+            + "            \"qty\": {\n"
+            + "              \"unit\": 0\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"sfkpgAcct\": {\n"
+            + "            \"id\": \"NECISOGEFRPPAGN000L10\"\n"
+            + "          },\n"
+            + "          \"cshAcct\": {\n"
+            + "            \"prtry\": \"CFREURSOGEFRPPTIT-DCA-SGSS\"\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"sttlmParams\": {\n"
+            + "          \"sctiesTxTp\": {\n"
+            + "            \"cd\": \"NETT\"\n"
+            + "          },\n"
+            + "          \"prtlSttlmInd\": \"PARQ\",\n"
+            + "          \"cshSubBalTp\": {\n"
+            + "            \"id\": \"DLVR\",\n"
+            + "            \"issr\": \"T2S\",\n"
+            + "            \"schmeNm\": \"RT\"\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"dlvrgSttlmPties\": {\n"
+            + "          \"dpstry\": {\n"
+            + "            \"id\": {\n"
+            + "              \"anyBIC\": \"ABCDEFGHXXX\"\n"
+            + "            },\n"
+            + "            \"prcgId\": \"2407162881091741\"\n"
+            + "          },\n"
+            + "          \"pty1\": {\n"
+            + "            \"id\": {\n"
+            + "              \"anyBIC\": \"QRSTUVWYXXX\"\n"
+            + "            },\n"
+            + "            \"sfkpgAcct\": {\n"
+            + "              \"id\": \"MOTICCEGITRRXXX9100000\"\n"
+            + "            },\n"
+            + "            \"prcgId\": \"1VUVZK\"\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"rcvgSttlmPties\": {\n"
+            + "          \"dpstry\": {\n"
+            + "            \"id\": {\n"
+            + "              \"anyBIC\": \"HGFEDCBAXXX\"\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"pty1\": {\n"
+            + "            \"id\": {\n"
+            + "              \"anyBIC\": \"SOGEFRPPAGN\"\n"
+            + "            },\n"
+            + "            \"sfkpgAcct\": {\n"
+            + "              \"id\": \"NECISOGEFRPPAGN000L10\"\n"
+            + "            },\n"
+            + "            \"prcgId\": \"FOO\"\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"sttldAmt\": {\n"
+            + "          \"amt\": {\n"
+            + "            \"value\": 1,\n"
+            + "            \"ccy\": \"EUR\"\n"
+            + "          },\n"
+            + "          \"cdtDbtInd\": \"DBIT\"\n"
+            + "        },\n"
+            + "        \"splmtryData\": [\n"
+            + "          {\n"
+            + "            \"plcAndNm\": \"/Document/SctiesSttlmTxConf/TxIdDtls\",\n"
+            + "            \"envlp\": {}\n"
+            + "          }\n"
+            + "        ]\n"
+            + "      },\n"
+            + "      \"appHdr\": {\n"
+            + "        \"fr\": {\n"
+            + "          \"fiId\": {\n"
+            + "            \"finInstnId\": {\n"
+            + "              \"bicfi\": \"IJKLMNOPXXX\",\n"
+            + "              \"othr\": {\n"
+            + "                \"id\": \"ABCDEFGHXXX\"\n"
+            + "              }\n"
+            + "            }\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"to\": {\n"
+            + "          \"fiId\": {\n"
+            + "            \"finInstnId\": {\n"
+            + "              \"bicfi\": \"ABCDEFGHXXX\",\n"
+            + "              \"othr\": {\n"
+            + "                \"id\": \"ABCDEFGHXXX\"\n"
+            + "              }\n"
+            + "            }\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"bizMsgIdr\": \"1423905641002\",\n"
+            + "        \"msgDefIdr\": \"sese.025.001.09\",\n"
+            + "        \"creDt\": {\n"
+            + "          \"dateTime\": {\n"
+            + "            \"date\": {\n"
+            + "              \"year\": 2024,\n"
+            + "              \"month\": 7,\n"
+            + "              \"day\": 17\n"
+            + "            },\n"
+            + "            \"time\": {\n"
+            + "              \"hour\": 5,\n"
+            + "              \"minute\": 27,\n"
+            + "              \"second\": 51,\n"
+            + "              \"nano\": 0\n"
+            + "            }\n"
+            + "          },\n"
+            + "          \"offset\": {\n"
+            + "            \"totalSeconds\": 0\n"
+            + "          }\n"
+            + "        },\n"
+            + "        \"cpyDplct\": \"COPY\",\n"
+            + "        \"pssblDplct\": true,\n"
+            + "        \"prty\": \"2024071700000208\",\n"
+            + "        \"namespace\": \"urn:iso:std:iso:20022:tech:xsd:head.001.001.01\"\n"
+            + "      },\n"
+            + "      \"type\": \"MX\",\n"
+            + "      \"@xmlns\": \"urn:iso:std:iso:20022:tech:xsd:sese.025.001.09\",\n"
+            + "      \"identifier\": \"sese.025.001.09\"\n"
+            + "    }";
+
+    @Test
+    void v10_should_be_able_to_parse_json_with_date_time_created_from_v9() {
+        final MxSese02500109 mx = (MxSese02500109) AbstractMX.fromJson(JSON_MX_V9);
+        assertThat(mx.getSctiesSttlmTxConf().getTradDtls().getTradDt().getDt().getDt())
+                .isNotNull(); // Success
+        assertThat(mx.getSctiesSttlmTxConf()
+                        .getTradDtls()
+                        .getFctvSttlmDt()
+                        .getDt()
+                        .getDtTm())
+                .isNotNull(); // Fail
     }
-    """;
 
-  private static final String JSON_MX_V10 = """
-    {
-      "sctiesSttlmTxConf": {
-        "txIdDtls": {
-          "acctOwnrTxId": "FOO",
-          "mktInfrstrctrTxId": "BAR",
-          "prcrTxId": "TOTO",
-          "sctiesMvmntTp": "RECE",
-          "pmt": "APMT",
-          "cmonId": "TITI"
-        },
-        "tradDtls": {
-          "plcOfTrad": {
-            "mktTpAndId": {
-              "tp": {
-                "cd": "EXCH"
-              }
-            }
-          },
-          "plcOfClr": {
-            "id": "QRSTUVWYXXX"
-          },
-          "tradDt": {
-            "dt": {
-              "dt": {
-                "year": 2024,
-                "month": 7,
-                "day": 16
-              }
-            }
-          },
-          "sttlmDt": {
-            "dt": {
-              "dt": {
-                "year": 2024,
-                "month": 7,
-                "day": 17
-              }
-            }
-          },
-          "fctvSttlmDt": {
-            "dt": {
-              "dtTm": {
-                "dateTime": {
-                  "date": {
-                    "year": 2024,
-                    "month": 7,
-                    "day": 17
-                  },
-                  "time": {
-                    "hour": 7,
-                    "minute": 26,
-                    "second": 4,
-                    "nano": 207459000
-                  }
-                },
-                "offset": {
-                  "totalSeconds": 7200
-                }
-              }
-            }
-          }
-        },
-        "finInstrmId": {
-          "isin": "NL0000009165"
-        },
-        "qtyAndAcctDtls": {
-          "sttldQty": {
-            "qty": {
-              "unit": 0
-            }
-          },
-          "sfkpgAcct": {
-            "id": "NECISOGEFRPPAGN000L10"
-          },
-          "cshAcct": {
-            "prtry": "CFREURSOGEFRPPTIT-DCA-SGSS"
-          }
-        },
-        "sttlmParams": {
-          "sctiesTxTp": {
-            "cd": "NETT"
-          },
-          "prtlSttlmInd": "PARQ",
-          "cshSubBalTp": {
-            "id": "DLVR",
-            "issr": "T2S",
-            "schmeNm": "RT"
-          }
-        },
-        "dlvrgSttlmPties": {
-          "dpstry": {
-            "id": {
-              "anyBIC": "ABCDEFGHXXX"
-            },
-            "prcgId": "2407162881091741"
-          },
-          "pty1": {
-            "id": {
-              "anyBIC": "QRSTUVWYXXX"
-            },
-            "sfkpgAcct": {
-              "id": "MOTICCEGITRRXXX9100000"
-            },
-            "prcgId": "1VUVZK"
-          }
-        },
-        "rcvgSttlmPties": {
-          "dpstry": {
-            "id": {
-              "anyBIC": "HGFEDCBAXXX"
-            }
-          },
-          "pty1": {
-            "id": {
-              "anyBIC": "SOGEFRPPAGN"
-            },
-            "sfkpgAcct": {
-              "id": "NECISOGEFRPPAGN000L10"
-            },
-            "prcgId": "FOO"
-          }
-        },
-        "sttldAmt": {
-          "amt": {
-            "value": 1,
-            "ccy": "EUR"
-          },
-          "cdtDbtInd": "DBIT"
-        },
-        "splmtryData": [
-          {
-            "plcAndNm": "/Document/SctiesSttlmTxConf/TxIdDtls",
-            "envlp": {}
-          }
-        ]
-      },
-      "appHdr": {
-        "fr": {
-          "fiId": {
-            "finInstnId": {
-              "bicfi": "IJKLMNOPXXX",
-              "othr": {
-                "id": "ABCDEFGHXXX"
-              }
-            }
-          }
-        },
-        "to": {
-          "fiId": {
-            "finInstnId": {
-              "bicfi": "ABCDEFGHXXX",
-              "othr": {
-                "id": "ABCDEFGHXXX"
-              }
-            }
-          }
-        },
-        "bizMsgIdr": "1423905641002",
-        "msgDefIdr": "sese.025.001.09",
-        "creDt": {
-          "dateTime": {
-            "date": {
-              "year": 2024,
-              "month": 7,
-              "day": 17
-            },
-            "time": {
-              "hour": 5,
-              "minute": 27,
-              "second": 51,
-              "nano": 0
-            }
-          },
-          "offset": {
-            "totalSeconds": 0
-          }
-        },
-        "cpyDplct": "COPY",
-        "pssblDplct": true,
-        "prty": "2024071700000208",
-        "namespace": "urn:iso:std:iso:20022:tech:xsd:head.001.001.01"
-      },
-      "type": "MX",
-      "@xmlns": "urn:iso:std:iso:20022:tech:xsd:sese.025.001.09",
-      "identifier": "sese.025.001.09"
+    @Test
+    void v10_should_be_able_to_parse_json_from_v9_and_read_same_content_than_json_from_v10_and_xml() {
+        final MxSese02500109 reference = (MxSese02500109) AbstractMX.parse(XML_MX);
+        final MxSese02500109 fromV9 = (MxSese02500109) AbstractMX.fromJson(JSON_MX_V9);
+        final String toV10 = reference.toJson();
+        final MxSese02500109 fromV10 = (MxSese02500109) AbstractMX.fromJson(JSON_MX_V10);
+
+        assertThat(fromV9).isEqualTo(reference);
+        assertThat(fromV10).isEqualTo(reference);
+        assertThat(fromV9).isEqualTo(fromV10);
+        assertThat(toV10).isEqualToIgnoringWhitespace(JSON_MX_V10);
+        assertThat(toV10).isNotEqualToIgnoringWhitespace(JSON_MX_V9);
     }
-    """;
-
-  @Test
-  void v10_should_be_able_to_parse_json_with_date_time_created_from_v9() {
-    final MxSese02500109 mx = (MxSese02500109) AbstractMX.fromJson(JSON_MX_V9);
-    assertThat(mx.getSctiesSttlmTxConf().getTradDtls().getTradDt().getDt().getDt()).isNotNull(); // Success
-    assertThat(mx.getSctiesSttlmTxConf().getTradDtls().getFctvSttlmDt().getDt().getDtTm()).isNotNull(); // Fail
-  }
-
-  @Test
-  void v10_should_be_able_to_parse_json_from_v9_and_read_same_content_than_json_from_v10_and_xml() {
-    final MxSese02500109 reference  = (MxSese02500109) AbstractMX.parse(XML_MX);
-    final MxSese02500109 fromV9     = (MxSese02500109) AbstractMX.fromJson(JSON_MX_V9);
-    final String         toV10      = reference.toJson();
-    final MxSese02500109 fromV10    = (MxSese02500109) AbstractMX.fromJson(JSON_MX_V10);
-
-    assertThat(fromV9).isEqualTo(reference);
-    assertThat(fromV10).isEqualTo(reference);
-    assertThat(fromV9).isEqualTo(fromV10);
-    assertThat(toV10).isEqualToIgnoringWhitespace(JSON_MX_V10);
-    assertThat(toV10).isNotEqualToIgnoringWhitespace(JSON_MX_V9);
-  }
 }

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/OffsetTimeJsonAdapterTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/OffsetTimeJsonAdapterTest.java
@@ -19,7 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import java.time.Instant;
 import java.time.OffsetTime;
+import java.util.TimeZone;
 import org.junit.jupiter.api.Test;
 
 class OffsetTimeJsonAdapterTest {
@@ -28,7 +30,11 @@ class OffsetTimeJsonAdapterTest {
 
     @Test
     void testSerializationAndDeserialization() {
-        int systemOffsetSeconds = OffsetTime.now().getOffset().getTotalSeconds();
+        int systemOffsetSeconds = TimeZone.getDefault()
+                .toZoneId()
+                .getRules()
+                .getStandardOffset(Instant.now())
+                .getTotalSeconds();
 
         // without offset, nano 0
         String jsonActual = "{\"time\":{\"hour\":12,\"minute\":13,\"second\":14,\"nano\":0}}";

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/OffsetTimeJsonAdapterTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/OffsetTimeJsonAdapterTest.java
@@ -21,7 +21,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import java.time.Instant;
 import java.time.OffsetTime;
-import java.util.TimeZone;
+import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
 
 class OffsetTimeJsonAdapterTest {
@@ -30,8 +30,7 @@ class OffsetTimeJsonAdapterTest {
 
     @Test
     void testSerializationAndDeserialization() {
-        int systemOffsetSeconds = TimeZone.getDefault()
-                .toZoneId()
+        int systemOffsetSeconds = ZoneId.systemDefault()
                 .getRules()
                 .getStandardOffset(Instant.now())
                 .getTotalSeconds();


### PR DESCRIPTION
Issue 118: Fix backward compatibility issue on DateTime fields seriaized from XMLGregorianCalendar objects

To be able to continue to parse JSON files generated from 9.x libraries using `AbstractMX.toJson()` when migrating to 10.x by doing an `AbstractMX.fromJson()`, which is a blocker for applications that were created before the existence of the 10.x branch and wouldn't be able anymore to read their previous files.

Another possibility could be to expose a public version of the `fromJson` method accepting custom adapters if you don't want to maintain the compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON deserialization for `OffsetDateTime` to support multiple DTO formats, improving flexibility and compatibility.
	- Added backward compatibility tests for ISO 20022 JSON representations to ensure seamless transitions between versions.
  
- **Bug Fixes**
	- Improved reliability in offset calculations for time-related tests to prevent inconsistencies across different time zones and daylight saving changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->