### PR TITLE
(PW-2810) CreDtTime-losing-trailing-zeros-in-millisecond

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ release.sh
 *.hprof
 .idea/copilot
 .java-version
+.claude
+.idea/copilot.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Prowide ISO 20022 - CHANGELOG
 
 ### 10.2.9 - SNAPSHOT
-  * (PW-2810) Fix: ISODateTime millisecond trailing zeros are omitted during XML marshal. Fixed to maintain milliseconds in the output to 3 decimal digits. 
+  * (PW-2810) Fix: ISODateTime fractional seconds losing trailing zeros during XML serialization, milliseconds now padded to exactly 3 digits. 
 
 ### 10.2.8 - September 2025
   * (PW-2637) Fix: do not consider copy duplicate flag (CpyDplct) in app header to mark the header a duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Prowide ISO 20022 - CHANGELOG
 
+### 10.2.9 - SNAPSHOT
+  * (PW-2810) Fix: ISODateTime millisecond trailing zeros are omitted during XML marshal. Fixed to maintain milliseconds in the output to 3 decimal digits. 
+
 ### 10.2.8 - September 2025
   * (PW-2637) Fix: do not consider copy duplicate flag (CpyDplct) in app header to mark the header a duplicate
   * Feat: Enhanced the `MxParseUtils` to be lenient when the XML declaration has empty or invalid version attribute

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,185 @@
+ # CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Prowide ISO 20022** is an open source Java framework for managing ISO 20022 MX messages. This library provides:
+- Java model for ISO 20022 MX messages (all categories: pacs, camt, pain, etc.)
+- XML parser to Java objects
+- Builder API from Java to XML
+- JSON conversion support
+
+This is a companion library to **Prowide Core** (https://github.com/prowide/prowide-core).
+
+## Build Commands
+
+### Full Build
+```bash
+./gradlew build
+```
+Compiles all modules, runs tests, and creates artifacts.
+
+### Run Tests
+```bash
+./gradlew test
+```
+Runs all tests across all modules.
+
+### Run Tests on Specific Module
+```bash
+./gradlew :iso20022-core:test
+```
+Replace `iso20022-core` with any module name.
+
+### Run Single Test Class
+```bash
+./gradlew :iso20022-core:test --tests "ClassName"
+```
+
+### Clean Build
+```bash
+./gradlew clean build
+```
+
+### Generate Javadoc
+```bash
+./gradlew javadoc
+```
+Output: `build/docs/javadoc/`
+
+### Create Individual Module JARs
+```bash
+./gradlew :iso20022-core:jar
+./gradlew :model-pacs-mx:jar
+./gradlew :model-camt-mx:jar
+# etc.
+```
+
+### Spotless (Code Formatting)
+```bash
+./gradlew spotlessCheck
+./gradlew spotlessApply
+```
+Only applies to `iso20022-core` module.
+
+## Architecture
+
+### Multi-Module Structure
+
+The project uses a modular architecture with **70+ Gradle subprojects** organized by ISO 20022 message category:
+
+```
+iso20022-core              → Core API, parsers, utilities, base classes (HAND-WRITTEN CODE)
+model-common-types         → Common business type dictionary (GENERATED CODE)
+model-[category]-mx        → Document/message classes for each category (GENERATED CODE)
+model-[category]-types     → Business type dictionaries specific to each category (GENERATED CODE)
+```
+
+**CRITICAL:** Only `iso20022-core` contains hand-written code. **ALL other 70+ subprojects are JAXB-generated from XSD schemas.**
+
+**Module Dependencies:**
+- `model-[category]-mx` depends on: `iso20022-core`, `model-[category]-types`, `model-common-types`
+- `model-[category]-types` depends on: `model-common-types`
+- `iso20022-core` depends on: `pw-swift-core` (from Prowide Core)
+
+### Source Structure
+
+**`iso20022-core` module:**
+```
+src/main/java       → Hand-written API code (MODIFY HERE)
+src/test/java       → Hand-written tests
+```
+
+**All other modules (model-*):**
+```
+src/generated/java  → JAXB-generated code from XSD schemas (DO NOT MODIFY)
+```
+
+**IMPORTANT:**
+- Never modify files in `src/generated/java` or any code in `model-*` modules
+- These are auto-generated from ISO 20022 XSD schemas and will be overwritten
+- You can **analyze specific files** in generated modules to understand message structure
+- **Never load entire generated modules as context** - there are thousands of generated classes
+
+### Core Components
+
+**In `iso20022-core` module:**
+
+- `AbstractMX` → Base class for all MX messages, handles parsing/serialization
+- `MxParseUtils` → Fast SAX-based XML parsing utilities (no DOM)
+- `MxWriteUtils` → XML serialization utilities
+- `AppHdr` / `AppHdrFactory` → Business Application Header handling (versions 1-4)
+- `MxReadConfiguration` / `MxWriteConfiguration` → Customizable parsing/serialization settings
+- Adapters (in `adapters/` package) → JAXB adapters for datetime, date, time serialization
+
+**Message Structure:**
+- Each MX message consists of: optional `AppHdr` (header) + `Document` (payload)
+- Document classes are in `model-[category]-mx` modules (e.g., `MxPacs00800102`)
+- Each message type follows pattern: `Mx{Category}{MessageType}{Version}` (e.g., `MxPacs00800102` = pacs.008.001.02)
+
+### Key Patterns
+
+1. **No Entity Exposure:** DTOs and projections are used, never expose JAXB entities directly in public APIs
+2. **JAXB-based:** Uses Jakarta XML Binding (JAXB 4.x) for XML marshalling/unmarshalling
+3. **Metadata Extraction:** `MxSwiftMessage` interface provides hooks for extracting sender, receiver, amounts, dates
+4. **Customizable Serialization:** Escape handlers, datetime adapters, namespace configurations all pluggable
+
+## Test Infrastructure
+
+- **Framework:** JUnit 5 + AssertJ
+- **XML Assertions:** XMLUnit for comparing XML structures
+- **Location:** Tests are only in `iso20022-core/src/test/java`
+- **Coverage:** Unit tests for parsers, serializers, adapters, utilities
+
+## Important Constraints
+
+### Code Generation
+- **Only `iso20022-core` is hand-written** - all other 70+ modules are JAXB-generated from XSD schemas
+- **Never propose changes to generated code** - it will be overwritten on next schema update
+- Analyze specific generated files when needed, but never load entire modules as context (too many classes)
+- All development and fixes should be done in `iso20022-core` module
+
+### JAXB/XML
+- Uses **Jakarta XML Binding 4.x** (not javax)
+- Requires Java 11+ (toolchain configured)
+- Custom datetime adapters handle ISO 8601 with milliseconds (3 digits)
+
+### Versioning
+- Uses **Axion Release Plugin** for Git-based versioning
+- Version format: `SRU{YEAR}-{semantic-version}` (e.g., `SRU2024-10.2.9`)
+- **SRU** (Standards Release Update) tracks SWIFT's annual schema releases
+- Always update `CHANGELOG.md` with functional, concise entries
+
+### Build Performance
+- **Very large codebase** - full build can be slow
+- Use module-specific tasks when possible: `./gradlew :iso20022-core:build`
+- Gradle parallel execution recommended (set in `gradle.properties`)
+
+### Javadoc
+- Only **subset of modules** included in Javadoc (see `projectsIncludedInJavadoc` in build.gradle)
+- Most `-types` and `-mx` modules have `javadoc.enabled = false`
+- Add `@since` tags with version from CHANGELOG.md for new public API
+- Use `@see` to avoid duplication
+- No `@author` tags
+
+## Dependencies
+
+- **Prowide Core:** `pw-swift-core` (companion library)
+- **JAXB:** `jaxb-impl:4.0.5` (Jakarta)
+- **JSON:** `gson:2.11.0`
+- **Utils:** `commons-lang3:3.17.0`
+- **Test:** JUnit 5, AssertJ, XMLUnit, Guava (test only)
+
+## Distribution
+
+- **Uber JAR:** Root project creates `pw-iso20022-SRU{YEAR}-{version}.jar` containing all modules
+- **Individual JARs:** Each module creates `pw-iso20022-{module-name}-SRU{YEAR}-{version}.jar`
+- **Maven Central:** Published as `com.prowidesoftware:pw-iso20022`
+- **Nexus Repository:** Internal releases/snapshots for licensed products
+
+## Java Version
+
+- **Source/Target:** Java 11
+- **Toolchain:** Configured to use Java 11 (`.java-version` file)
+- **Testing:** Can test on Java 17/21 with `testOn17` and `testOn21` tasks

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
@@ -1,6 +1,7 @@
 package com.prowidesoftware.issues;
 
 import com.prowidesoftware.swift.model.mx.*;
+import com.prowidesoftware.swift.model.mx.adapters.IsoDateTimeAdapter;
 import com.prowidesoftware.swift.model.mx.adapters.OffsetDateTimeAdapter;
 import java.time.OffsetDateTime;
 import org.apache.commons.lang3.StringUtils;
@@ -43,13 +44,11 @@ public class IssueJira2810Test {
         // String strXML = amx.message();
         // System.out.println("AMX:" + strXML);
         MxPacs00800108 mx = new MxPacs00800108(xml);
-        // default date time adapter contains the offset
-        String strXML1 = mx.message();
-        System.out.println("MX:" + strXML1);
-
         // custom serialization using a custom date time adapter
-        // MxWriteConfiguration config = new MxWriteConfiguration();
-        // config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new CustomDateTimeAdapter());
+        MxWriteConfiguration config = new MxWriteConfiguration();
+        config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new CustomDateTimeAdapter());
+        String strXML1 = mx.message(config);
+        System.out.println("MX:" + strXML1);
     }
 
     public class CustomDateTimeAdapter extends OffsetDateTimeAdapter {

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
@@ -5,6 +5,7 @@ import com.prowidesoftware.swift.model.mx.adapters.IsoDateTimeAdapter;
 import com.prowidesoftware.swift.model.mx.adapters.OffsetDateTimeAdapter;
 import java.time.OffsetDateTime;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class IssueJira2810Test {
@@ -48,7 +49,7 @@ public class IssueJira2810Test {
         MxWriteConfiguration config = new MxWriteConfiguration();
         config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new CustomDateTimeAdapter());
         String strXML1 = mx.message(config);
-        System.out.println("MX:" + strXML1);
+        Assertions.assertTrue(strXML1.contains("<pacs:CreDtTm>2025-09-16T12:31:42.780-03:00</pacs:CreDtTm>"));
     }
 
     public class CustomDateTimeAdapter extends OffsetDateTimeAdapter {

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
@@ -1,0 +1,74 @@
+package com.prowidesoftware.issues;
+
+import com.prowidesoftware.swift.model.mx.*;
+import com.prowidesoftware.swift.model.mx.adapters.OffsetDateTimeAdapter;
+import java.time.OffsetDateTime;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+public class IssueJira2810Test {
+    @Test
+    public void testCreationDt() {
+        String xml = "";
+        MxPacs00900108 mx = new MxPacs00900108(xml);
+        // default date time adapter contains the offset
+        String strXML = mx.message();
+        System.out.println(strXML);
+
+        // custom serialization using a custom date time adapter
+        // MxWriteConfiguration config = new MxWriteConfiguration();
+        // config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new CustomDateTimeAdapter());
+    }
+
+    @Test
+    public void testXMLCreationDt() {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<message>"
+                + "<AppHdr xmlns=\"urn:swift:xsd:$ahV10\">"
+                + "<From>"
+                + "	<Type>DN</Type>"
+                + " <Id>cn=funds,o=abcdchzzwww,o=swift</Id>"
+                + "</From>"
+                + "<To>"
+                + "	<Type>DN</Type>"
+                + "	<Id>cn=funds,o=dcbadeff,o=swift</Id>"
+                + "</To>"
+                + "	<MsgRef>11308917</MsgRef>"
+                + "	<CrDate>2013-12-23T15:50:00</CrDate>"
+                + "</AppHdr>"
+                + "<Document xmlns=\"urn:iso:std:iso:20022:tech:xsd:pacs.008.001.08\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.six-interbank-clearing.com/de/pacs.008.001.02.ch.01 pacs.008.001.02.ch.01.xsd\">"
+                + "<FIToFICstmrCdtTrf>"
+                + "	<GrpHdr>"
+                + "		<MsgId>MSGID-0001</MsgId>"
+                + "		<CreDtTm>2025-09-16T12:31:42.780-03:00</CreDtTm>"
+                + "		<NbOfTxs>1</NbOfTxs>"
+                + "		<IntrBkSttlmDt>2012-01-25</IntrBkSttlmDt>"
+                + "		<SttlmInf><SttlmMtd>INDA</SttlmMtd></SttlmInf>"
+                + "		<InstgAgt><FinInstnId><BIC>KBBECH20DSZ</BIC></FinInstnId></InstgAgt>"
+                + "		<InstdAgt><FinInstnId><BIC>DRESDEF0VNZ</BIC></FinInstnId></InstdAgt>"
+                + "	</GrpHdr>"
+                + "	<CdtTrfTxInf>"
+                + " </CdtTrfTxInf>"
+                + "</FIToFICstmrCdtTrf>"
+                + "</Document>"
+                + "</message>";
+        // AbstractMX amx = AbstractMX.parse(xml);
+        // String strXML = amx.message();
+        // System.out.println("AMX:" + strXML);
+        MxPacs00800108 mx = new MxPacs00800108(xml);
+        // default date time adapter contains the offset
+        String strXML1 = mx.message();
+        System.out.println("MX:" + strXML1);
+
+        // custom serialization using a custom date time adapter
+        // MxWriteConfiguration config = new MxWriteConfiguration();
+        // config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new CustomDateTimeAdapter());
+    }
+
+    public class CustomDateTimeAdapter extends OffsetDateTimeAdapter {
+        @Override
+        public String marshal(OffsetDateTime offsetDateTime) throws Exception {
+            return StringUtils.replace(super.marshal(offsetDateTime), "+00:00", "Z");
+        }
+    }
+}

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
@@ -1,11 +1,6 @@
 package com.prowidesoftware.issues;
 
 import com.prowidesoftware.swift.model.mx.*;
-import com.prowidesoftware.swift.model.mx.adapters.IsoDateTimeAdapter;
-import com.prowidesoftware.swift.model.mx.adapters.OffsetDateTimeAdapter;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.temporal.ChronoField;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +42,7 @@ public class IssueJira2810Test {
         MxPacs00800108 mx = new MxPacs00800108(xml);
         // custom serialization using a custom date time adapter
         MxWriteConfiguration config = new MxWriteConfiguration();
-        DateTimeFormatter dateTimeFormatterBuilder = new DateTimeFormatterBuilder()
+        /*DateTimeFormatter dateTimeFormatterBuilder = new DateTimeFormatterBuilder()
                 .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
                 .optionalStart()
                 .appendFraction(ChronoField.NANO_OF_SECOND, 3, 3, true)
@@ -57,7 +52,8 @@ public class IssueJira2810Test {
                 .optionalEnd()
                 .toFormatter();
         config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new OffsetDateTimeAdapter(dateTimeFormatterBuilder));
-        String strXML1 = mx.message(config);
+         */
+        String strXML1 = mx.message();
         // Modified value after Fix
         Assertions.assertTrue(strXML1.contains("<pacs:CreDtTm>2025-09-16T12:31:42.780-03:00</pacs:CreDtTm>"));
     }

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
@@ -3,8 +3,9 @@ package com.prowidesoftware.issues;
 import com.prowidesoftware.swift.model.mx.*;
 import com.prowidesoftware.swift.model.mx.adapters.IsoDateTimeAdapter;
 import com.prowidesoftware.swift.model.mx.adapters.OffsetDateTimeAdapter;
-import java.time.OffsetDateTime;
-import org.apache.commons.lang3.StringUtils;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,20 +44,21 @@ public class IssueJira2810Test {
                 + "</message>";
         // AbstractMX amx = AbstractMX.parse(xml);
         // String strXML = amx.message();
-        // System.out.println("AMX:" + strXML);
         MxPacs00800108 mx = new MxPacs00800108(xml);
         // custom serialization using a custom date time adapter
         MxWriteConfiguration config = new MxWriteConfiguration();
-        config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new CustomDateTimeAdapter());
+        DateTimeFormatter dateTimeFormatterBuilder = new DateTimeFormatterBuilder()
+                .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+                .optionalStart()
+                .appendFraction(ChronoField.NANO_OF_SECOND, 3, 3, true)
+                .optionalEnd()
+                .optionalStart()
+                .appendPattern("XXX")
+                .optionalEnd()
+                .toFormatter();
+        config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new OffsetDateTimeAdapter(dateTimeFormatterBuilder));
         String strXML1 = mx.message(config);
-        // Modify value after Fix
-        Assertions.assertTrue(strXML1.contains("<pacs:CreDtTm>2025-09-16T12:31:42.78-03:00</pacs:CreDtTm>"));
-    }
-
-    public class CustomDateTimeAdapter extends OffsetDateTimeAdapter {
-        @Override
-        public String marshal(OffsetDateTime offsetDateTime) throws Exception {
-            return StringUtils.replace(super.marshal(offsetDateTime), "+00:00", "Z");
-        }
+        // Modified value after Fix
+        Assertions.assertTrue(strXML1.contains("<pacs:CreDtTm>2025-09-16T12:31:42.780-03:00</pacs:CreDtTm>"));
     }
 }

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
@@ -49,7 +49,8 @@ public class IssueJira2810Test {
         MxWriteConfiguration config = new MxWriteConfiguration();
         config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new CustomDateTimeAdapter());
         String strXML1 = mx.message(config);
-        Assertions.assertTrue(strXML1.contains("<pacs:CreDtTm>2025-09-16T12:31:42.780-03:00</pacs:CreDtTm>"));
+        //Modify after Fix
+        Assertions.assertTrue(strXML1.contains("<pacs:CreDtTm>2025-09-16T12:31:42.78-03:00</pacs:CreDtTm>"));
     }
 
     public class CustomDateTimeAdapter extends OffsetDateTimeAdapter {

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
@@ -49,7 +49,7 @@ public class IssueJira2810Test {
         MxWriteConfiguration config = new MxWriteConfiguration();
         config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new CustomDateTimeAdapter());
         String strXML1 = mx.message(config);
-        //Modify after Fix
+        // Modify value after Fix
         Assertions.assertTrue(strXML1.contains("<pacs:CreDtTm>2025-09-16T12:31:42.78-03:00</pacs:CreDtTm>"));
     }
 

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/IssueJira2810Test.java
@@ -8,19 +8,6 @@ import org.junit.jupiter.api.Test;
 
 public class IssueJira2810Test {
     @Test
-    public void testCreationDt() {
-        String xml = "";
-        MxPacs00900108 mx = new MxPacs00900108(xml);
-        // default date time adapter contains the offset
-        String strXML = mx.message();
-        System.out.println(strXML);
-
-        // custom serialization using a custom date time adapter
-        // MxWriteConfiguration config = new MxWriteConfiguration();
-        // config.adapters.dateTimeAdapter = new IsoDateTimeAdapter(new CustomDateTimeAdapter());
-    }
-
-    @Test
     public void testXMLCreationDt() {
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
                 + "<message>"

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/OffsetDateTimeAdapterTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/OffsetDateTimeAdapterTest.java
@@ -25,8 +25,8 @@ class OffsetDateTimeAdapterTest {
 
         // DateTime without offset and with/without fractional seconds
         testDateTimeImpl("2021-09-19T12:13:14", "2021-09-19T12:13:14" + offset);
-        testDateTimeImpl("2021-09-19T12:13:14.1", "2021-09-19T12:13:14.1" + offset);
-        testDateTimeImpl("2021-09-19T12:13:14.12", "2021-09-19T12:13:14.12" + offset);
+        testDateTimeImpl("2021-09-19T12:13:14.1", "2021-09-19T12:13:14.100" + offset);
+        testDateTimeImpl("2021-09-19T12:13:14.12", "2021-09-19T12:13:14.120" + offset);
         testDateTimeImpl("2021-09-19T12:13:14.123", "2021-09-19T12:13:14.123" + offset);
         testDateTimeImpl("2021-09-19T12:13:14.123456789", "2021-09-19T12:13:14.123456789" + offset);
 
@@ -39,8 +39,8 @@ class OffsetDateTimeAdapterTest {
         testDateTimeImpl("2021-09-19T12:13:14Z", "2021-09-19T12:13:14+00:00");
 
         // DateTime with offset and fractional seconds
-        testDateTimeImpl("2021-09-19T12:13:14.1+01:00", "2021-09-19T12:13:14.1+01:00");
-        testDateTimeImpl("2021-09-19T12:13:14.12-01:00", "2021-09-19T12:13:14.12-01:00");
+        testDateTimeImpl("2021-09-19T12:13:14.1+01:00", "2021-09-19T12:13:14.100+01:00");
+        testDateTimeImpl("2021-09-19T12:13:14.12-01:00", "2021-09-19T12:13:14.120-01:00");
         testDateTimeImpl("2021-09-19T12:13:14.123+00:00", "2021-09-19T12:13:14.123+00:00");
         testDateTimeImpl("2021-09-19T12:13:14.123+08:30", "2021-09-19T12:13:14.123+08:30");
         testDateTimeImpl("2021-09-19T12:13:14.000+08:30", "2021-09-19T12:13:14+08:30");
@@ -73,7 +73,7 @@ class OffsetDateTimeAdapterTest {
 
         // non removable zeros
         testDateTimeImpl("2018-01-15T17:30:33.0+02:00", "2018-01-15T17:30:33+02:00");
-        testDateTimeImpl("2018-01-15T17:30:33.01+02:00", "2018-01-15T17:30:33.01+02:00");
+        testDateTimeImpl("2018-01-15T17:30:33.01+02:00", "2018-01-15T17:30:33.010+02:00");
         testDateTimeImpl("2018-01-15T17:30:33.001+02:00", "2018-01-15T17:30:33.001+02:00");
         testDateTimeImpl("2018-01-15T17:30:33.0001+02:00", "2018-01-15T17:30:33.0001+02:00");
         testDateTimeImpl("2018-01-15T17:30:33.00001+02:00", "2018-01-15T17:30:33.00001+02:00");


### PR DESCRIPTION
while calling message method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - ISO date-time fractional seconds are preserved and padded to three digits during XML marshalling.
  - UTC “Z” timestamps are normalized to “+00:00” for consistent output.
  - Improves serialization consistency for pacs.008 messages.

- Tests
  - Added/updated unit tests validating fractional-second padding, UTC normalization, and pacs.008 serialization.

- Documentation
  - Changelog updated with 10.2.9 entry.
  - New contributor guidance document added.

- Chores
  - .gitignore updated with additional patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->