### PR TITLE
Fix: capture xsd:any wildcard content on parse and in JSON (PWUS-18, GH-39, GH-43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ### 10.3.9 - SNAPSHOT
   * Feat: `xsd:any` wildcard content (e.g. `SplmtryData/Envlp`, signature envelopes) is no longer dropped on parse; it is captured as an `org.w3c.dom.Element` with namespaces preserved (GH-39, GH-43)
   * Fix: `toJson()` now serializes `@XmlAnyElement` wildcard content as raw XML instead of an empty `{}`, and `fromJson()` restores it back to a DOM Element (round-trippable)
+  * Updated gson from 2.13.2 to 2.14.0
 
 ### 10.3.8 - May 2026
   * (PW-3202) Fix: removed spurious `Error propagating pending prefix mapping` warnings when parsing regular ISO 20022 Documents wrapped in an SNL-like envelope
   * (PW-3185) `MxSwiftMessage.toJson()` now uses 1-based months (January=1) for Calendar fields and emits a `schemaVersion` marker. `fromJson()` reads both new and legacy (0-based) payloads transparently.
-  * Updated gson from 2.13.2 to 2.14.0
 
 ### 10.3.7 - April 2026
   * (PW-3207) Fix: update semt.044.001.01 model from draft4 to draft5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Prowide ISO 20022 - CHANGELOG
 
+### 10.3.9 - SNAPSHOT
+  * Feat: `xsd:any` wildcard content (e.g. `SplmtryData/Envlp`, signature envelopes) is no longer dropped on parse; it is captured as an `org.w3c.dom.Element` with namespaces preserved (GH-39, GH-43)
+  * Fix: `toJson()` now serializes `@XmlAnyElement` wildcard content as raw XML instead of an empty `{}`, and `fromJson()` restores it back to a DOM Element (round-trippable)
+
 ### 10.3.8 - May 2026
   * (PW-3202) Fix: removed spurious `Error propagating pending prefix mapping` warnings when parsing regular ISO 20022 Documents wrapped in an SNL-like envelope
   * (PW-3185) `MxSwiftMessage.toJson()` now uses 1-based months (January=1) for Calendar fields and emits a `schemaVersion` marker. `fromJson()` reads both new and legacy (0-based) payloads transparently.

--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,8 @@ project(':iso20022-core') {
 		testImplementation 'org.xmlunit:xmlunit-assertj:2.12.0'
 		testImplementation project(':model-acmt-mx')
 		testImplementation project(':model-acmt-types')
+		testImplementation project(':model-admi-mx')
+		testImplementation project(':model-admi-types')
 		testImplementation project(':model-camt-mx')
 		testImplementation project(':model-camt-types')
 		testImplementation project(':model-catm-mx')

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/AbstractMX.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/AbstractMX.java
@@ -191,7 +191,9 @@ public abstract class AbstractMX extends AbstractMessage implements JsonSerializ
      */
     protected static <T> T fromJson(String json, Class<T> classOfT) {
         final Gson gson = getGsonBuilderWithV10Adapters();
-        return gson.fromJson(json, classOfT);
+        T parsed = gson.fromJson(json, classOfT);
+        WildcardElementRepair.repair(parsed);
+        return parsed;
     }
 
     /**
@@ -203,7 +205,9 @@ public abstract class AbstractMX extends AbstractMessage implements JsonSerializ
      */
     public static AbstractMX fromJson(String json) {
         final Gson gson = getGsonBuilderWithV10Adapters();
-        return gson.fromJson(json, AbstractMX.class);
+        AbstractMX mx = gson.fromJson(json, AbstractMX.class);
+        WildcardElementRepair.repair(mx);
+        return mx;
     }
 
     /**
@@ -221,7 +225,9 @@ public abstract class AbstractMX extends AbstractMessage implements JsonSerializ
      */
     protected static <T> T fromJsonV9(String json, Class<T> classOfT) {
         final Gson gson = getGsonBuilderWithV9Adapters();
-        return gson.fromJson(json, classOfT);
+        T parsed = gson.fromJson(json, classOfT);
+        WildcardElementRepair.repair(parsed);
+        return parsed;
     }
 
     /**
@@ -237,7 +243,9 @@ public abstract class AbstractMX extends AbstractMessage implements JsonSerializ
      */
     public static AbstractMX fromJsonV9(String json) {
         final Gson gson = getGsonBuilderWithV9Adapters();
-        return gson.fromJson(json, AbstractMX.class);
+        AbstractMX mx = gson.fromJson(json, AbstractMX.class);
+        WildcardElementRepair.repair(mx);
+        return mx;
     }
 
     /**
@@ -568,7 +576,11 @@ public abstract class AbstractMX extends AbstractMessage implements JsonSerializ
                 .registerTypeAdapter(LocalDate.class, new LocalDateJsonAdapter())
                 .registerTypeAdapter(Year.class, new YearJsonAdapter())
                 .registerTypeAdapter(YearMonth.class, new YearMonthJsonAdapter())
-                .registerTypeAdapter(AppHdr.class, new AppHdrAdapter());
+                .registerTypeAdapter(AppHdr.class, new AppHdrAdapter())
+                // serialize xsd:any wildcard content (e.g. SupplementaryData/Envlp, signature
+                // envelopes) as raw XML instead of an empty object; hierarchy registration is
+                // required because the runtime value is a concrete DOM impl, not Element itself
+                .registerTypeHierarchyAdapter(Element.class, new ElementJsonAdapter());
     }
 
     private static Gson getGsonBuilderWithV9Adapters() {

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/NamespaceAndElementFilter.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/NamespaceAndElementFilter.java
@@ -176,7 +176,11 @@ public class NamespaceAndElementFilter extends XMLFilterImpl {
             throws SAXException {
         List<String> forwarded = entryForwarded != null ? entryForwarded : new ArrayList<>();
         for (PrefixMapping pm : bufferedStartMappings) {
-            if (wildcard || isXsysNamespace(pm.url)) {
+            // Forward every mapping except the main namespace, which we unbind. This keeps xsys and
+            // foreign declarations in scope downstream so that a wildcard descendant can still resolve
+            // a foreign prefix declared on a (main-namespace) ancestor. In wildcard mode we forward
+            // everything verbatim, including a re-declared main namespace.
+            if (wildcard || !StringUtils.equals(pm.url, this.mainNamespace)) {
                 try {
                     super.startPrefixMapping(pm.prefix, pm.url);
                     forwarded.add(pm.prefix);

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/NamespaceAndElementFilter.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/NamespaceAndElementFilter.java
@@ -15,7 +15,9 @@
  */
 package com.prowidesoftware.swift.model.mx;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -28,9 +30,15 @@ import org.xml.sax.helpers.XMLFilterImpl;
  * This filter enables extraction of a particular element from an XML.
  *
  * <p>The filter will bypass only the main element being parsed (such as the AppHdr or Document), ignoring any other
- * sibling or parent content such as a transmission envelope. Then within the main element being processed, only the
- * content with a recognized namespace is propagated, meaning for example any supplementary data with Any in the schema
- * will not be parsed.
+ * sibling or parent content such as a transmission envelope. Within the main element being processed, content in the
+ * main message namespace is unbound (the namespace is stripped) and content in the SWIFT xsys namespaces is kept as is.
+ * Any other content (foreign namespace or no namespace) is treated as {@code xsd:any} wildcard content (for example a
+ * {@code SplmtryData/Envlp} payload or a signature envelope) and is forwarded verbatim, with its namespaces intact, so
+ * that JAXB's {@code @XmlAnyElement} binding can materialize it as a {@link org.w3c.dom.Element}.
+ *
+ * <p>Known limitation: a wildcard child that happens to reuse the exact main message namespace is treated as model
+ * content (unbound), not captured as wildcard, because the filter keys its decision purely on the namespace. This does
+ * not affect the usual wildcard payloads, which use a foreign namespace or no namespace.
  *
  * <p>Regarding the namespace, two different behaviours are supported; bounded or unbounded.
  *
@@ -52,10 +60,18 @@ public class NamespaceAndElementFilter extends XMLFilterImpl {
     private String mainNamespace;
     private boolean inElementToPropagate = false;
     private final String localNameToPropagate;
-    private boolean inInnerElementToSkip = false;
-    private String localNameToSkip;
     private final boolean unbindNamespace;
     private final List<PrefixMapping> pendingPrefixMappings = new ArrayList<>();
+
+    // Element depth within the propagated element (incremented on every forwarded startElement).
+    private int depth = 0;
+    // Depth at which we entered an xsd:any wildcard subtree, or -1 when not inside one.
+    private int wildcardDepth = -1;
+    // Prefix mappings buffered until the upcoming startElement reveals whether to forward them.
+    private final List<PrefixMapping> bufferedStartMappings = new ArrayList<>();
+    // Per-forwarded-element list of prefixes actually forwarded, so the matching endPrefixMapping
+    // events can be synthesized in endElement (LIFO), keeping the downstream namespace stack balanced.
+    private final Deque<List<String>> forwardedPrefixStack = new ArrayDeque<>();
 
     private static class PrefixMapping {
         final String prefix;
@@ -89,11 +105,10 @@ public class NamespaceAndElementFilter extends XMLFilterImpl {
     public void startElement(String namespace, String localName, String prefix, Attributes attributes)
             throws SAXException {
 
-        if (inInnerElementToSkip) {
-            return;
-        }
+        // Prefixes forwarded as part of entering the propagated element (GH-168 xsys replay).
+        List<String> entryForwarded = null;
 
-        if (!this.inElementToPropagate && localName.equals(this.localNameToPropagate)) {
+        if (wildcardDepth < 0 && !this.inElementToPropagate && localName.equals(this.localNameToPropagate)) {
             this.inElementToPropagate = true;
             this.mainNamespace = namespace;
 
@@ -103,9 +118,11 @@ public class NamespaceAndElementFilter extends XMLFilterImpl {
             // for regular ISO 20022 Documents would be unnecessary and can produce spurious warnings
             // or namespace-stack errors in strict SAX-to-StAX bridges.
             if (isXsysDocumentNamespace(this.mainNamespace)) {
+                entryForwarded = new ArrayList<>();
                 for (PrefixMapping pm : pendingPrefixMappings) {
                     try {
                         super.startPrefixMapping(pm.prefix, pm.url);
+                        entryForwarded.add(pm.prefix);
                     } catch (Exception e) {
                         log.warning("Error propagating pending prefix mapping " + pm.prefix + " [" + pm.url + "]: "
                                 + exceptionMessage(e));
@@ -118,25 +135,84 @@ public class NamespaceAndElementFilter extends XMLFilterImpl {
             pendingPrefixMappings.clear();
         }
 
+        if (wildcardDepth >= 0) {
+            // Already inside an xsd:any wildcard subtree: forward the content verbatim with its
+            // original namespace so JAXB's @XmlAnyElement binding materializes it as a DOM Element.
+            forwardStart(namespace, localName, prefix, attributes, true, entryForwarded);
+            return;
+        }
+
         if (this.inElementToPropagate) {
             String namespaceToPropagate = resolveNamespaceToPropagate(namespace);
             if (namespaceToPropagate != null) {
-                try {
-                    super.startElement(namespaceToPropagate, localName, prefix, attributes);
-                } catch (Exception e) {
-                    log.warning("Error parsing " + localName + " [" + namespace + "] element: " + exceptionMessage(e));
-                    if (log.isLoggable(Level.FINEST)) {
-                        log.log(Level.FINEST, "Error parsing " + localName + " [" + namespace + "] element", e);
-                    }
-                }
+                // recognized content: main namespace (unbound to "") or xsys namespace (kept as is)
+                forwardStart(namespaceToPropagate, localName, prefix, attributes, false, entryForwarded);
             } else {
-                // we have found an element within the structure to propagate with a not recognized namespace
-                // so we skip this content because we don't have the model to unmarshall it properly;
-                // this is normally the case of an Any element in the schema
-                this.inInnerElementToSkip = true;
-                this.localNameToSkip = localName;
+                // foreign or no-namespace content within the structure to propagate: this is the
+                // xsd:any wildcard case. Enter wildcard mode and forward the subtree verbatim so
+                // JAXB captures it as an org.w3c.dom.Element instead of dropping it.
+                this.wildcardDepth = this.depth;
+                forwardStart(namespace, localName, prefix, attributes, true, entryForwarded);
             }
         }
+    }
+
+    /**
+     * Forwards a startElement downstream, first flushing the buffered prefix mappings that apply to
+     * it and recording the forwarded prefixes on {@link #forwardedPrefixStack} so the matching end
+     * mappings can be synthesized on the corresponding endElement.
+     *
+     * @param namespaceToPropagate the namespace to forward (already resolved/unbound for non-wildcard content)
+     * @param wildcard true to forward every buffered mapping verbatim (wildcard content); false to forward only xsys
+     * @param entryForwarded prefixes already forwarded while entering the propagated element (GH-168), or null
+     */
+    private void forwardStart(
+            String namespaceToPropagate,
+            String localName,
+            String prefix,
+            Attributes attributes,
+            boolean wildcard,
+            List<String> entryForwarded)
+            throws SAXException {
+        List<String> forwarded = entryForwarded != null ? entryForwarded : new ArrayList<>();
+        for (PrefixMapping pm : bufferedStartMappings) {
+            if (wildcard || isXsysNamespace(pm.url)) {
+                try {
+                    super.startPrefixMapping(pm.prefix, pm.url);
+                    forwarded.add(pm.prefix);
+                } catch (Exception e) {
+                    log.warning(
+                            "Error parsing " + pm.prefix + " [" + pm.url + "] prefix mapping: " + exceptionMessage(e));
+                    if (log.isLoggable(Level.FINEST)) {
+                        log.log(Level.FINEST, "Error parsing " + pm.prefix + " [" + pm.url + "] prefix mapping", e);
+                    }
+                }
+            }
+        }
+        bufferedStartMappings.clear();
+        forwardedPrefixStack.push(forwarded);
+        try {
+            super.startElement(
+                    namespaceToPropagate, localName, unboundQName(namespaceToPropagate, localName, prefix), attributes);
+        } catch (Exception e) {
+            log.warning(
+                    "Error parsing " + localName + " [" + namespaceToPropagate + "] element: " + exceptionMessage(e));
+            if (log.isLoggable(Level.FINEST)) {
+                log.log(Level.FINEST, "Error parsing " + localName + " [" + namespaceToPropagate + "] element", e);
+            }
+        }
+        depth++;
+    }
+
+    /**
+     * Returns the qualified name to forward downstream. When the element namespace has been unbound
+     * (resolved to an empty namespace) the original prefix must be dropped, because an element in no
+     * namespace cannot carry a prefix; keeping it would leave an undeclared prefix that breaks the
+     * DOM construction performed by JAXB for wildcard ({@code @XmlAnyElement}) content reusing the main
+     * namespace. For elements that keep their namespace (xsys or foreign wildcard) the qName is kept.
+     */
+    private static String unboundQName(String namespaceToPropagate, String localName, String qName) {
+        return (namespaceToPropagate == null || namespaceToPropagate.isEmpty()) ? localName : qName;
     }
 
     private String resolveNamespaceToPropagate(String namespace) {
@@ -184,54 +260,89 @@ public class NamespaceAndElementFilter extends XMLFilterImpl {
     @Override
     public void endElement(String namespace, String localName, String prefix) throws SAXException {
 
-        if (this.inInnerElementToSkip) {
-            if (localName.equals(this.localNameToSkip)) {
-                // stop skipping
-                this.inInnerElementToSkip = false;
-                this.localNameToSkip = null;
-                return;
+        if (wildcardDepth >= 0) {
+            // Inside a wildcard subtree: forward verbatim. Check before decrementing whether this
+            // closes the wildcard root element.
+            boolean closingWildcardRoot = (this.depth - 1 == this.wildcardDepth);
+            forwardEnd(namespace, localName, prefix);
+            if (closingWildcardRoot) {
+                this.wildcardDepth = -1;
             }
+            return;
         }
 
         if (this.inElementToPropagate) {
             String namespaceToPropagate = resolveNamespaceToPropagate(namespace);
             if (namespaceToPropagate != null) {
-                try {
-                    super.endElement(namespaceToPropagate, localName, prefix);
-                } catch (Exception e) {
-                    log.warning("Error parsing " + localName + " [" + namespace + "] element: " + exceptionMessage(e));
-                    if (log.isLoggable(Level.FINEST)) {
-                        log.log(Level.FINEST, "Error parsing " + localName + " [" + namespace + "] element", e);
-                    }
-                }
+                forwardEnd(namespaceToPropagate, localName, prefix);
             }
         }
 
         if (localName.equals(this.localNameToPropagate)) {
-            // we are done (we will skip the rest of the XML content
+            // we are done (we will skip the rest of the XML content); reset state defensively
             this.inElementToPropagate = false;
+            this.depth = 0;
+            this.wildcardDepth = -1;
+            this.forwardedPrefixStack.clear();
+            this.bufferedStartMappings.clear();
         }
+    }
+
+    /**
+     * Forwards an endElement downstream and then synthesizes the matching endPrefixMapping events
+     * (in reverse order) for the prefixes that were forwarded on the corresponding startElement,
+     * keeping the downstream namespace stack balanced.
+     */
+    private void forwardEnd(String namespaceToPropagate, String localName, String prefix) throws SAXException {
+        try {
+            super.endElement(namespaceToPropagate, localName, unboundQName(namespaceToPropagate, localName, prefix));
+        } catch (Exception e) {
+            log.warning(
+                    "Error parsing " + localName + " [" + namespaceToPropagate + "] element: " + exceptionMessage(e));
+            if (log.isLoggable(Level.FINEST)) {
+                log.log(Level.FINEST, "Error parsing " + localName + " [" + namespaceToPropagate + "] element", e);
+            }
+        }
+        if (!forwardedPrefixStack.isEmpty()) {
+            List<String> forwarded = forwardedPrefixStack.pop();
+            for (int i = forwarded.size() - 1; i >= 0; i--) {
+                try {
+                    super.endPrefixMapping(forwarded.get(i));
+                } catch (Exception e) {
+                    log.warning("Error ending prefix mapping " + forwarded.get(i) + ": " + exceptionMessage(e));
+                    if (log.isLoggable(Level.FINEST)) {
+                        log.log(Level.FINEST, "Error ending prefix mapping " + forwarded.get(i), e);
+                    }
+                }
+            }
+        }
+        depth--;
     }
 
     @Override
     public void startPrefixMapping(String prefix, String url) throws SAXException {
-        if (isXsysNamespace(url)) {
-            if (this.inElementToPropagate && this.mainNamespace != null) {
-                // we only propagate the xsys messages namespaces, for the main namespace we want it unbounded
-                try {
-                    super.startPrefixMapping(prefix, url);
-                } catch (Exception e) {
-                    log.warning("Error parsing " + prefix + " [" + url + "] prefix mapping: " + exceptionMessage(e));
-                    if (log.isLoggable(Level.FINEST)) {
-                        log.log(Level.FINEST, "Error parsing " + prefix + " [" + url + "] prefix mapping", e);
-                    }
-                }
-            } else {
-                // Store xsys namespace mappings that appear before the element to propagate
-                // This handles the case where AppHdr with xsys namespaces appears before Document
-                pendingPrefixMappings.add(new PrefixMapping(prefix, url));
-            }
+        if (this.inElementToPropagate) {
+            // Inside the propagated subtree the decision (unbind the main namespace, keep xsys, or
+            // capture wildcard content) depends on the upcoming element, which SAX delivers right
+            // after these mappings. Buffer them and let startElement decide which to forward, so
+            // start and end prefix mappings stay balanced downstream.
+            bufferedStartMappings.add(new PrefixMapping(prefix, url));
+        } else if (isXsysNamespace(url)) {
+            // Store xsys namespace mappings that appear before the element to propagate, to replay
+            // them if the propagated element turns out to be an xsys Document (GH-168 / PW-3202).
+            // This handles the case where AppHdr with xsys namespaces appears before Document.
+            pendingPrefixMappings.add(new PrefixMapping(prefix, url));
         }
+        // other mappings declared outside the propagated element are dropped
+    }
+
+    @Override
+    public void endPrefixMapping(String prefix) throws SAXException {
+        // Intentionally a no-op. The matching end prefix mapping events are synthesized in endElement
+        // from forwardedPrefixStack, so they balance exactly the start mappings we forwarded. Letting
+        // XMLFilterImpl forward every endPrefixMapping (including the unbound main namespace and the
+        // dropped outer-envelope mappings) is what underflows the downstream JAXB namespace stack,
+        // producing the negative-index ArrayIndexOutOfBoundsException.
     }
 
     private static String exceptionMessage(Exception e) {

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/NamespaceAndElementFilter.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/NamespaceAndElementFilter.java
@@ -36,9 +36,10 @@ import org.xml.sax.helpers.XMLFilterImpl;
  * {@code SplmtryData/Envlp} payload or a signature envelope) and is forwarded verbatim, with its namespaces intact, so
  * that JAXB's {@code @XmlAnyElement} binding can materialize it as a {@link org.w3c.dom.Element}.
  *
- * <p>Known limitation: a wildcard child that happens to reuse the exact main message namespace is treated as model
- * content (unbound), not captured as wildcard, because the filter keys its decision purely on the namespace. This does
- * not affect the usual wildcard payloads, which use a foreign namespace or no namespace.
+ * <p>Known limitation: a wildcard child that reuses the exact main message namespace is still captured as an
+ * {@link org.w3c.dom.Element}, but with its namespace unbound, so its original namespace URI is not round-tripped.
+ * This happens because the filter keys its decision purely on the namespace. It does not affect the usual wildcard
+ * payloads, which use a foreign namespace or no namespace.
  *
  * <p>Regarding the namespace, two different behaviours are supported; bounded or unbounded.
  *

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/WildcardElementRepair.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/WildcardElementRepair.java
@@ -19,12 +19,15 @@ import com.prowidesoftware.swift.model.mx.adapters.ElementJsonAdapter;
 import jakarta.xml.bind.annotation.XmlAnyElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.w3c.dom.Element;
@@ -49,6 +52,10 @@ final class WildcardElementRepair {
     private static final Logger log = Logger.getLogger(WildcardElementRepair.class.getName());
     private static final String MODEL_PACKAGE = "com.prowidesoftware.swift.model.mx";
 
+    // Per-class cache of the instance fields to visit (flattened across the hierarchy, made accessible
+    // once). Avoids repeated getDeclaredFields()/setAccessible() reflection on every deserialization.
+    private static final Map<Class<?>, Field[]> FIELD_CACHE = new ConcurrentHashMap<>();
+
     private WildcardElementRepair() {}
 
     /**
@@ -67,22 +74,44 @@ final class WildcardElementRepair {
         if (obj == null || !visited.add(obj)) {
             return;
         }
-        for (Class<?> c = obj.getClass(); c != null && c != Object.class; c = c.getSuperclass()) {
-            for (Field field : c.getDeclaredFields()) {
-                if (Modifier.isStatic(field.getModifiers()) || field.isSynthetic()) {
-                    continue;
-                }
-                final Object value = readField(field, obj);
-                if (value == null) {
-                    continue;
-                }
-                if (field.isAnnotationPresent(XmlAnyElement.class)) {
-                    repairWildcard(field, obj, value);
-                } else {
-                    recurse(value, visited);
-                }
+        for (Field field : instanceFields(obj.getClass())) {
+            final Object value = readField(field, obj);
+            if (value == null) {
+                continue;
+            }
+            if (field.isAnnotationPresent(XmlAnyElement.class)) {
+                repairWildcard(field, obj, value);
+            } else {
+                recurse(value, visited);
             }
         }
+    }
+
+    /**
+     * Returns (and caches) the non-static instance fields of the given class flattened across its
+     * hierarchy, with {@link Field#setAccessible(boolean)} already applied.
+     */
+    private static Field[] instanceFields(final Class<?> type) {
+        return FIELD_CACHE.computeIfAbsent(type, t -> {
+            final List<Field> fields = new ArrayList<>();
+            for (Class<?> c = t; c != null && c != Object.class; c = c.getSuperclass()) {
+                for (Field field : c.getDeclaredFields()) {
+                    if (Modifier.isStatic(field.getModifiers()) || field.isSynthetic()) {
+                        continue;
+                    }
+                    try {
+                        field.setAccessible(true);
+                    } catch (Exception e) {
+                        if (log.isLoggable(Level.FINEST)) {
+                            log.log(Level.FINEST, "Cannot access field " + field.getName(), e);
+                        }
+                        continue;
+                    }
+                    fields.add(field);
+                }
+            }
+            return fields.toArray(new Field[0]);
+        });
     }
 
     private static void repairWildcard(final Field field, final Object owner, final Object value) {
@@ -127,7 +156,6 @@ final class WildcardElementRepair {
 
     private static Object readField(final Field field, final Object owner) {
         try {
-            field.setAccessible(true);
             return field.get(owner);
         } catch (Exception e) {
             if (log.isLoggable(Level.FINEST)) {
@@ -139,7 +167,6 @@ final class WildcardElementRepair {
 
     private static void writeField(final Field field, final Object owner, final Object value) {
         try {
-            field.setAccessible(true);
             field.set(owner, value);
         } catch (Exception e) {
             log.warning("Could not restore wildcard element on field " + field.getName() + ": " + e.getMessage());

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/WildcardElementRepair.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/WildcardElementRepair.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2006-2026 Prowide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.prowidesoftware.swift.model.mx;
+
+import com.prowidesoftware.swift.model.mx.adapters.ElementJsonAdapter;
+import jakarta.xml.bind.annotation.XmlAnyElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.w3c.dom.Element;
+
+/**
+ * Restores {@code @XmlAnyElement} wildcard content after JSON deserialization.
+ *
+ * <p>Wildcard fields declared as {@code Object} (for example {@code SupplementaryDataEnvelope1.any}) are
+ * deserialized by Gson's built-in object adapter as the raw XML {@link String} produced by
+ * {@link ElementJsonAdapter}, because the declared field type gives Gson no reason to route them to the
+ * {@code Element} adapter. A {@code String} left in such a field would be marshalled by JAXB as escaped
+ * text instead of a child element, breaking the XML round-trip. This utility walks the deserialized object
+ * graph and converts those encoded strings back into {@link org.w3c.dom.Element} instances.
+ *
+ * <p>Fields typed as {@code List<Element>} (for example {@code SwAny.any}) are deserialized correctly by
+ * Gson on their own; this utility still repairs any string items defensively.
+ *
+ * @since 10.3.9
+ */
+final class WildcardElementRepair {
+
+    private static final Logger log = Logger.getLogger(WildcardElementRepair.class.getName());
+    private static final String MODEL_PACKAGE = "com.prowidesoftware.swift.model.mx";
+
+    private WildcardElementRepair() {}
+
+    /**
+     * Walks the given object graph restoring {@code @XmlAnyElement} string values into DOM elements.
+     *
+     * @param root the deserialized message (or any model object); null is ignored
+     */
+    static void repair(final Object root) {
+        if (root == null) {
+            return;
+        }
+        walk(root, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private static void walk(final Object obj, final Set<Object> visited) {
+        if (obj == null || !visited.add(obj)) {
+            return;
+        }
+        for (Class<?> c = obj.getClass(); c != null && c != Object.class; c = c.getSuperclass()) {
+            for (Field field : c.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers()) || field.isSynthetic()) {
+                    continue;
+                }
+                final Object value = readField(field, obj);
+                if (value == null) {
+                    continue;
+                }
+                if (field.isAnnotationPresent(XmlAnyElement.class)) {
+                    repairWildcard(field, obj, value);
+                } else {
+                    recurse(value, visited);
+                }
+            }
+        }
+    }
+
+    private static void repairWildcard(final Field field, final Object owner, final Object value) {
+        if (value instanceof String) {
+            final Element element = ElementJsonAdapter.toElement((String) value);
+            if (element != null) {
+                writeField(field, owner, element);
+            }
+        } else if (value instanceof List) {
+            @SuppressWarnings("unchecked")
+            final ListIterator<Object> it = ((List<Object>) value).listIterator();
+            while (it.hasNext()) {
+                final Object item = it.next();
+                if (item instanceof String) {
+                    final Element element = ElementJsonAdapter.toElement((String) item);
+                    if (element != null) {
+                        it.set(element);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void recurse(final Object value, final Set<Object> visited) {
+        if (value instanceof Collection) {
+            for (Object item : (Collection<?>) value) {
+                recurse(item, visited);
+            }
+        } else if (isModelObject(value)) {
+            walk(value, visited);
+        }
+    }
+
+    private static boolean isModelObject(final Object value) {
+        final Class<?> type = value.getClass();
+        if (type.isPrimitive() || type.isEnum() || type.isArray()) {
+            return false;
+        }
+        final Package pkg = type.getPackage();
+        return pkg != null && pkg.getName().startsWith(MODEL_PACKAGE);
+    }
+
+    private static Object readField(final Field field, final Object owner) {
+        try {
+            field.setAccessible(true);
+            return field.get(owner);
+        } catch (Exception e) {
+            if (log.isLoggable(Level.FINEST)) {
+                log.log(Level.FINEST, "Could not read field " + field.getName(), e);
+            }
+            return null;
+        }
+    }
+
+    private static void writeField(final Field field, final Object owner, final Object value) {
+        try {
+            field.setAccessible(true);
+            field.set(owner, value);
+        } catch (Exception e) {
+            log.warning("Could not restore wildcard element on field " + field.getName() + ": " + e.getMessage());
+        }
+    }
+}

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/adapters/ElementJsonAdapter.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/adapters/ElementJsonAdapter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2006-2026 Prowide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.prowidesoftware.swift.model.mx.adapters;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.prowidesoftware.swift.utils.SafeXmlUtils;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.lang.reflect.Type;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+/**
+ * Gson {@link JsonSerializer} and {@link JsonDeserializer} for {@link org.w3c.dom.Element}, used to
+ * preserve {@code xsd:any} wildcard content (such as {@code SplmtryData/Envlp} payloads or signature
+ * envelopes) when an MX message is converted to/from JSON.
+ *
+ * <p>Without this adapter Gson reflects over the DOM node and serializes it as an empty object
+ * ({@code {}}), losing the content. The element is represented as its raw XML serialization (a JSON
+ * string), which is lossless for arbitrary subtrees including namespaces, attributes and mixed content.
+ *
+ * <p>It must be registered with {@code registerTypeHierarchyAdapter(Element.class, ...)} rather than
+ * {@code registerTypeAdapter}, because at runtime the value is a concrete DOM implementation (e.g.
+ * {@code ElementNSImpl}), not the {@link Element} interface itself.
+ *
+ * @since 10.3.9
+ */
+public class ElementJsonAdapter implements JsonSerializer<Element>, JsonDeserializer<Element> {
+
+    @Override
+    public JsonElement serialize(Element element, Type typeOfSrc, JsonSerializationContext context) {
+        if (element == null) {
+            return JsonNull.INSTANCE;
+        }
+        try {
+            Transformer transformer = SafeXmlUtils.transformer();
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            StringWriter writer = new StringWriter();
+            transformer.transform(new DOMSource(element), new StreamResult(writer));
+            return new JsonPrimitive(writer.toString());
+        } catch (Exception e) {
+            throw new JsonParseException("Error serializing org.w3c.dom.Element to JSON", e);
+        }
+    }
+
+    @Override
+    public Element deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        if (json == null || json.isJsonNull() || !json.isJsonPrimitive()) {
+            return null;
+        }
+        return toElement(json.getAsString());
+    }
+
+    /**
+     * Parses an XML string into a detached {@link org.w3c.dom.Element} using the hardened
+     * (XXE-safe), namespace-aware document builder. Returns {@code null} for null or blank input.
+     *
+     * @param xml the raw XML serialization of an element
+     * @return the parsed element, or {@code null} if the input is null/blank
+     * @throws JsonParseException if the XML cannot be parsed
+     */
+    public static Element toElement(String xml) {
+        if (xml == null || xml.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            // namespace-aware so the restored element exposes localName/namespaceURI and re-marshals correctly
+            Document document = SafeXmlUtils.documentBuilder(true).parse(new InputSource(new StringReader(xml)));
+            return document.getDocumentElement();
+        } catch (Exception e) {
+            throw new JsonParseException("Error deserializing org.w3c.dom.Element from JSON", e);
+        }
+    }
+}

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/Issue11.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/Issue11.java
@@ -19,10 +19,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.prowidesoftware.swift.model.mx.BusinessAppHdrV01;
 import com.prowidesoftware.swift.model.mx.MxPacs00200108;
+import com.prowidesoftware.swift.model.mx.dic.SupplementaryDataEnvelope1;
 import com.prowidesoftware.swift.utils.Lib;
 import java.io.IOException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
 
 /**
  * https://github.com/prowide/prowide-iso20022/issues/11
@@ -30,16 +31,27 @@ import org.junit.jupiter.api.Test;
 public class Issue11 {
 
     /*
-     * Supplementary data is not bounded to any namespace
-     * Signature element in header is missing namespace
+     * Supplementary data and signature reuse their parent (main) namespace. Previously this crashed the
+     * JAXB UnmarshallingContext (negative-index namespace error) and the message could not be parsed.
+     * The wildcard content is now forwarded with balanced prefix mappings, so the message parses and the
+     * SplmtryData/Envlp content is captured as a DOM Element instead of being dropped.
      */
-    @Disabled("Forcing namespace error prevents the UnmarshallingContext from getting the asserted state")
     @Test
     public void test() throws IOException {
         String xml = Lib.readResource("issues/11/samplemsg.002.001.08.txt");
         assertNotNull(xml);
         MxPacs00200108 mx = MxPacs00200108.parse(xml);
-        assertNull(mx);
+        assertMessage(mx);
+
+        SupplementaryDataEnvelope1 envlp = mx.getFIToFIPmtStsRpt()
+                .getTxInfAndSts()
+                .get(0)
+                .getSplmtryData()
+                .get(0)
+                .getEnvlp();
+        assertNotNull(envlp.getAny());
+        assertTrue(envlp.getAny() instanceof Element);
+        assertEquals("InstrForCdtrAcct", ((Element) envlp.getAny()).getLocalName());
     }
 
     private void assertMessage(MxPacs00200108 mx) {

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/Issue39.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/Issue39.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2006-2026 Prowide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.prowidesoftware.issues;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.prowidesoftware.swift.model.mx.MxAdmi00700101;
+import com.prowidesoftware.swift.model.mx.dic.SupplementaryDataEnvelope1;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+
+/**
+ * https://github.com/prowide/prowide-iso20022/issues/39
+ *
+ * <p>Parsing an admi.007.001.01 message dropped the {@code SplmtryData/Envlp} content. The
+ * {@code <Document>} declares a default namespace, so {@code <FromBOData>} (un-prefixed) belongs to the
+ * message main namespace; the wildcard content is now captured as a {@link org.w3c.dom.Element}.
+ */
+public class Issue39 {
+
+    // Payload as posted in the issue.
+    private static final String XML = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
+            + "<Body>\n"
+            + "    <AppHdr xmlns=\"urn:iso:std:iso:20022:tech:xsd:head.001.001.01\">\n"
+            + "        <Fr>\n"
+            + "            <FIId>\n"
+            + "                <FinInstnId>\n"
+            + "                    <BICFI>XXXXXXXXXXX</BICFI>\n"
+            + "                </FinInstnId>\n"
+            + "            </FIId>\n"
+            + "        </Fr>\n"
+            + "        <To>\n"
+            + "            <FIId>\n"
+            + "                <FinInstnId>\n"
+            + "                    <BICFI>XXXXXXXXXXX</BICFI>\n"
+            + "                </FinInstnId>\n"
+            + "            </FIId>\n"
+            + "        </To>\n"
+            + "        <BizMsgIdr>XXXXXXX</BizMsgIdr>\n"
+            + "        <MsgDefIdr>admi.007.001.01</MsgDefIdr>\n"
+            + "        <CreDt>2022-01-11T15:02:09Z</CreDt>\n"
+            + "    </AppHdr>\n"
+            + "    <Document xmlns=\"urn:iso:std:iso:20022:tech:xsd:admi.007.001.01\">\n"
+            + "        <RctAck>\n"
+            + "            <MsgId>\n"
+            + "                <MsgId>XXXXXXX</MsgId>\n"
+            + "            </MsgId>\n"
+            + "            <Rpt>\n"
+            + "                <RltdRef>\n"
+            + "                    <Ref>XXXXXX</Ref>\n"
+            + "                </RltdRef>\n"
+            + "                <ReqHdlg>\n"
+            + "                    <StsCd>ACKT</StsCd>\n"
+            + "                    <Desc>CR50</Desc>\n"
+            + "                </ReqHdlg>\n"
+            + "            </Rpt>\n"
+            + "            <SplmtryData>\n"
+            + "                <Envlp>\n"
+            + "                    <FromBOData>TOTO</FromBOData>\n"
+            + "                </Envlp>\n"
+            + "            </SplmtryData>\n"
+            + "        </RctAck>\n"
+            + "    </Document>\n"
+            + "</Body>";
+
+    @Test
+    public void test() {
+        MxAdmi00700101 mx = MxAdmi00700101.parse(XML);
+        assertThat(mx).isNotNull();
+        assertThat(mx.getRctAck().getRpt().get(0).getReqHdlg().getStsCd()).isEqualTo("ACKT");
+
+        SupplementaryDataEnvelope1 envlp =
+                mx.getRctAck().getSplmtryData().get(0).getEnvlp();
+        Element any = (Element) envlp.getAny();
+        assertThat(any).isNotNull();
+        assertThat(any.getLocalName()).isEqualTo("FromBOData");
+        assertThat(any.getTextContent().trim()).isEqualTo("TOTO");
+    }
+}

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/Issue41.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/Issue41.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2006-2026 Prowide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.prowidesoftware.issues;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.prowidesoftware.swift.model.mx.sys.MxXsys00300101;
+import com.prowidesoftware.swift.model.mx.sys.dic.SwAny;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+
+/**
+ * https://github.com/prowide/prowide-iso20022/issues/41
+ *
+ * <p>{@code ThirdPartyRefusalReason} in xsys.003.001.01 is of type {@code SwAny}, which is bound to
+ * {@code @XmlAnyElement List<Element>}: it captures child <b>elements</b>, never plain text. The issue
+ * reported the field with text content ({@code <Sw:ThirdPartyRefusalReason>ABCD</...>}); such text has
+ * no place in the model and is therefore not captured (see {@link #textContentIsNotCapturedByDesign()}).
+ * Child element content, which previously was dropped by the namespace filter, is now captured (see
+ * {@link #childElementContentIsCaptured()}).
+ */
+public class Issue41 {
+
+    /**
+     * The payload exactly as posted in the issue: a 4-character text in {@code ThirdPartyRefusalReason}.
+     * {@code SwAny.any} is a {@code List<Element>}, so the text cannot be bound; the list stays empty.
+     * This is a model/schema characteristic (the type only allows child elements), not a parser bug.
+     */
+    @Test
+    public void textContentIsNotCapturedByDesign() {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<Doc:Document xmlns:Doc=\"urn:swift:xsd:xsys.003.001.01\" xmlns:Sw=\"urn:swift:snl:ns.Sw\">"
+                + "  <Doc:xsys.003.001.01>"
+                + "    <Doc:AuthstnRfslNtfctn>"
+                + "      <Sw:SnFRef>swi00001</Sw:SnFRef>"
+                + "      <Sw:ThirdPartyRefusalReason>ABCD</Sw:ThirdPartyRefusalReason>"
+                + "    </Doc:AuthstnRfslNtfctn>"
+                + "  </Doc:xsys.003.001.01>"
+                + "</Doc:Document>";
+
+        MxXsys00300101 mx = MxXsys00300101.parse(xml);
+        assertThat(mx).isNotNull();
+
+        SwAny swAny = mx.getXsys00300101().getAuthstnRfslNtfctn().getThirdPartyRefusalReason();
+        assertThat(swAny).isNotNull();
+        assertThat(swAny.getAny()).isEmpty();
+    }
+
+    /**
+     * Realistic xsd:any usage: {@code ThirdPartyRefusalReason} carries a child element. A
+     * foreign-namespace child was previously dropped by the namespace filter; it is now captured as a
+     * {@link org.w3c.dom.Element}.
+     */
+    @Test
+    public void childElementContentIsCaptured() {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<Doc:Document xmlns:Doc=\"urn:swift:xsd:xsys.003.001.01\" xmlns:Sw=\"urn:swift:snl:ns.Sw\">"
+                + "  <Doc:xsys.003.001.01>"
+                + "    <Doc:AuthstnRfslNtfctn>"
+                + "      <Sw:SnFRef>swi00001</Sw:SnFRef>"
+                + "      <Sw:ThirdPartyRefusalReason>"
+                + "        <Rsn xmlns=\"urn:example:refusal\">ABCD</Rsn>"
+                + "      </Sw:ThirdPartyRefusalReason>"
+                + "    </Doc:AuthstnRfslNtfctn>"
+                + "  </Doc:xsys.003.001.01>"
+                + "</Doc:Document>";
+
+        MxXsys00300101 mx = MxXsys00300101.parse(xml);
+        assertThat(mx).isNotNull();
+
+        SwAny swAny = mx.getXsys00300101().getAuthstnRfslNtfctn().getThirdPartyRefusalReason();
+        assertThat(swAny).isNotNull();
+        List<Element> any = swAny.getAny();
+        assertThat(any).hasSize(1);
+        assertThat(any.get(0).getLocalName()).isEqualTo("Rsn");
+        assertThat(any.get(0).getNamespaceURI()).isEqualTo("urn:example:refusal");
+        assertThat(any.get(0).getTextContent().trim()).isEqualTo("ABCD");
+    }
+}

--- a/iso20022-core/src/test/java/com/prowidesoftware/issues/Issue43.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/issues/Issue43.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2006-2026 Prowide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.prowidesoftware.issues;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.prowidesoftware.swift.model.mx.BusinessAppHdrV01;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+
+/**
+ * https://github.com/prowide/prowide-iso20022/issues/43
+ *
+ * <p>Parsing a BusinessAppHdrV01 whose {@code Sgntr/SignatureEnvelope} wildcard element is declared with a
+ * default (un-prefixed) foreign namespace ({@code xmlns="http://www.w3.org/2000/09/xmldsig#"}) left the
+ * {@code any} field null. The reporter noted it worked with a prefixed namespace declaration but not with a
+ * default one. The signature envelope is now captured as a {@link org.w3c.dom.Element}.
+ */
+public class Issue43 {
+
+    @Test
+    public void test() {
+        // Header reproducing the issue: schemaLocation present, signature in a default foreign namespace.
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<AppHdr xsi:schemaLocation=\"urn:iso:std:iso:20022:tech:xsd:head.001.001.01 head.001.001.01.xsd\""
+                + "        xmlns=\"urn:iso:std:iso:20022:tech:xsd:head.001.001.01\""
+                + "        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
+                + "  <Fr><FIId><FinInstnId><BICFI>AAAAUS00</BICFI></FinInstnId></FIId></Fr>"
+                + "  <To><FIId><FinInstnId><BICFI>BBBBUS00</BICFI></FinInstnId></FIId></To>"
+                + "  <BizMsgIdr>X</BizMsgIdr>"
+                + "  <MsgDefIdr>pacs.008.001.03</MsgDefIdr>"
+                + "  <CreDt>2022-01-11T15:02:09Z</CreDt>"
+                + "  <Sgntr>"
+                + "    <XMLSgntrs xmlns=\"http://www.w3.org/2000/09/xmldsig#\">"
+                + "      <SignatureValue>abc</SignatureValue>"
+                + "    </XMLSgntrs>"
+                + "  </Sgntr>"
+                + "</AppHdr>";
+
+        BusinessAppHdrV01 h = BusinessAppHdrV01.parse(xml);
+        assertThat(h).isNotNull();
+        assertThat(h.getSgntr()).isNotNull();
+
+        Element any = (Element) h.getSgntr().getAny();
+        assertThat(any).isNotNull();
+        assertThat(any.getLocalName()).isEqualTo("XMLSgntrs");
+        assertThat(any.getNamespaceURI()).isEqualTo("http://www.w3.org/2000/09/xmldsig#");
+    }
+}

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/NamespaceAndElementFilterTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/NamespaceAndElementFilterTest.java
@@ -15,6 +15,7 @@
  */
 package com.prowidesoftware.swift.model.mx;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.prowidesoftware.swift.utils.SafeXmlUtils;
@@ -22,6 +23,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
@@ -79,6 +81,39 @@ class NamespaceAndElementFilterTest {
                 "Expected SwGbl prefix mapping to be replayed for xsys Document, got: " + handler.prefixMappings);
     }
 
+    /**
+     * Foreign-namespace xsd:any wildcard content (e.g. SplmtryData/Envlp payloads) must be forwarded
+     * downstream with its namespace intact, and the start/end prefix mappings must be balanced. An
+     * imbalance is what underflowed the downstream JAXB namespace stack (negative-index error) and
+     * caused the wildcard content to be dropped before this fix.
+     */
+    @Test
+    void forwardsWildcardContentWithBalancedPrefixMappings() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<Doc:Document xmlns:Doc=\"urn:iso:std:iso:20022:tech:xsd:pacs.002.001.08\">"
+                + "  <Doc:SplmtryData>"
+                + "    <Doc:Envlp>"
+                + "      <TEST:TestData xmlns:TEST=\"appian:test:smm\">"
+                + "        <TEST:tag>Hello World!</TEST:tag>"
+                + "      </TEST:TestData>"
+                + "    </Doc:Envlp>"
+                + "  </Doc:SplmtryData>"
+                + "</Doc:Document>";
+
+        RecordingHandler handler = runFilter(xml, "Document");
+
+        assertTrue(
+                handler.prefixMappings.contains("TEST=appian:test:smm"),
+                "wildcard prefix mapping should be forwarded, got: " + handler.prefixMappings);
+        assertTrue(
+                handler.elements.contains("appian:test:smm:TestData"),
+                "wildcard element should be forwarded with its namespace, got: " + handler.elements);
+        assertEquals(
+                handler.startMappingCount,
+                handler.endMappingCount,
+                "startPrefixMapping and endPrefixMapping must be balanced downstream");
+    }
+
     private static RecordingHandler runFilter(String xml, String elementToPropagate) throws Exception {
         RecordingHandler handler = new RecordingHandler();
         NamespaceAndElementFilter filter = new NamespaceAndElementFilter(elementToPropagate);
@@ -91,10 +126,24 @@ class NamespaceAndElementFilterTest {
 
     private static class RecordingHandler extends DefaultHandler {
         final List<String> prefixMappings = new ArrayList<>();
+        final List<String> elements = new ArrayList<>();
+        int startMappingCount = 0;
+        int endMappingCount = 0;
 
         @Override
         public void startPrefixMapping(String prefix, String uri) {
             prefixMappings.add(prefix + "=" + uri);
+            startMappingCount++;
+        }
+
+        @Override
+        public void endPrefixMapping(String prefix) {
+            endMappingCount++;
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes attributes) {
+            elements.add(uri + ":" + localName);
         }
     }
 }

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/WildcardAnyParsingTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/WildcardAnyParsingTest.java
@@ -147,6 +147,41 @@ class WildcardAnyParsingTest {
         assertThat(restoredAny.getLocalName()).isEqualTo("TestData");
     }
 
+    /**
+     * Edge case: a foreign prefix is declared on a main-namespace ancestor ({@code SplmtryData}) and consumed
+     * by a wildcard descendant ({@code TEST:TestData}) that does not redeclare it. The filter must keep the
+     * foreign declaration in scope downstream (it only drops the main namespace), so the descendant is captured.
+     */
+    @Test
+    void wildcardDescendantUsesForeignPrefixFromMainNamespaceAncestor() {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<Document xmlns=\"urn:iso:std:iso:20022:tech:xsd:camt.056.001.08\">"
+                + "  <FIToFIPmtCxlReq>"
+                + "    <Assgnmt>"
+                + "      <Id>ID-1</Id>"
+                + "      <CreDtTm>2024-01-01T10:00:00</CreDtTm>"
+                + "    </Assgnmt>"
+                + "    <SplmtryData xmlns:TEST=\"foocorp:test:smm\">"
+                + "      <PlcAndNm>TxSupplementary</PlcAndNm>"
+                + "      <Envlp>"
+                + "        <TEST:TestData><TEST:tag>Hello World!</TEST:tag></TEST:TestData>"
+                + "      </Envlp>"
+                + "    </SplmtryData>"
+                + "  </FIToFIPmtCxlReq>"
+                + "</Document>";
+
+        MxCamt05600108 mx = MxCamt05600108.parse(xml);
+        assertThat(mx).isNotNull();
+
+        SupplementaryDataEnvelope1 envlp =
+                mx.getFIToFIPmtCxlReq().getSplmtryData().get(0).getEnvlp();
+        Element any = (Element) envlp.getAny();
+        assertThat(any).isNotNull();
+        assertThat(any.getLocalName()).isEqualTo("TestData");
+        assertThat(any.getNamespaceURI()).isEqualTo("foocorp:test:smm");
+        assertThat(any.getTextContent().trim()).isEqualTo("Hello World!");
+    }
+
     private static SupplementaryDataEnvelope1 envelope(MxPacs00200108 mx) {
         return mx.getFIToFIPmtStsRpt()
                 .getTxInfAndSts()

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/WildcardAnyParsingTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/WildcardAnyParsingTest.java
@@ -96,6 +96,57 @@ class WildcardAnyParsingTest {
         assertThat(restored.message()).contains("InstrForCdtrAcct").contains("RsdntSts");
     }
 
+    /**
+     * PWUS-18 exact reproduction: a camt.056.001.08 whose root-level SplmtryData/Envlp carries a custom
+     * namespaced XML payload. Previously the JSON rendered {@code "envelope": {}}; now the content is
+     * captured on parse, emitted in JSON, and restored by fromJson.
+     */
+    @Test
+    void camt056SupplementaryDataEnvelopeRoundTrips() {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<Document xmlns=\"urn:iso:std:iso:20022:tech:xsd:camt.056.001.08\">"
+                + "  <FIToFIPmtCxlReq>"
+                + "    <Assgnmt>"
+                + "      <Id>ID-1</Id>"
+                + "      <Assgnr><Agt><FinInstnId><BICFI>AAAAUS00</BICFI></FinInstnId></Agt></Assgnr>"
+                + "      <Assgne><Agt><FinInstnId><BICFI>BBBBUS00</BICFI></FinInstnId></Agt></Assgne>"
+                + "      <CreDtTm>2024-01-01T10:00:00</CreDtTm>"
+                + "    </Assgnmt>"
+                + "    <SplmtryData>"
+                + "      <PlcAndNm>TxSupplementary</PlcAndNm>"
+                + "      <Envlp>"
+                + "        <TEST:TestData xmlns:TEST=\"foocorp:test:smm\">"
+                + "          <TEST:tag>Hello World!</TEST:tag>"
+                + "        </TEST:TestData>"
+                + "      </Envlp>"
+                + "    </SplmtryData>"
+                + "  </FIToFIPmtCxlReq>"
+                + "</Document>";
+
+        MxCamt05600108 mx = MxCamt05600108.parse(xml);
+        assertThat(mx).isNotNull();
+
+        SupplementaryDataEnvelope1 envlp =
+                mx.getFIToFIPmtCxlReq().getSplmtryData().get(0).getEnvlp();
+        Element any = (Element) envlp.getAny();
+        assertThat(any).isNotNull();
+        assertThat(any.getLocalName()).isEqualTo("TestData");
+        assertThat(any.getNamespaceURI()).isEqualTo("foocorp:test:smm");
+        assertThat(any.getTextContent().trim()).isEqualTo("Hello World!");
+
+        // JSON must contain the payload, not the empty "envelope": {} of the original bug
+        String json = mx.toJson();
+        assertThat(json).contains("TestData").contains("Hello World!");
+        assertThat(json).doesNotContain("\"envelope\": {}");
+
+        // and fromJson restores it back to a DOM Element
+        MxCamt05600108 restored = MxCamt05600108.fromJson(json);
+        Element restoredAny = (Element)
+                restored.getFIToFIPmtCxlReq().getSplmtryData().get(0).getEnvlp().getAny();
+        assertThat(restoredAny).isNotNull();
+        assertThat(restoredAny.getLocalName()).isEqualTo("TestData");
+    }
+
     private static SupplementaryDataEnvelope1 envelope(MxPacs00200108 mx) {
         return mx.getFIToFIPmtStsRpt()
                 .getTxInfAndSts()

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/WildcardAnyParsingTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/WildcardAnyParsingTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2006-2026 Prowide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.prowidesoftware.swift.model.mx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.prowidesoftware.swift.model.mx.dic.SupplementaryDataEnvelope1;
+import com.prowidesoftware.swift.utils.Lib;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+
+/**
+ * Regression coverage for the AnyTagParsing issues (#39, #41, #43, PWUS-18): xsd:any wildcard content
+ * (SplmtryData/Envlp payloads and signature envelopes) must be captured as org.w3c.dom.Element on parse,
+ * preserved on XML round-trip, and serialized/restored through JSON instead of being dropped.
+ */
+class WildcardAnyParsingTest {
+
+    /** Foreign-namespace SplmtryData/Envlp payload must be captured as a DOM Element (PWUS-18). */
+    @Test
+    void capturesForeignNamespaceSupplementaryData() throws IOException {
+        MxPacs00200108 mx =
+                MxPacs00200108.parse(Lib.readResource("issues/11/samplemsg.002.001.08-SplmtryData_with_namespace.xml"));
+
+        Element any = (Element) envelope(mx).getAny();
+        assertThat(any).isNotNull();
+        assertThat(any.getLocalName()).isEqualTo("InstrForCdtrAcct");
+        assertThat(any.getNamespaceURI()).isEqualTo("foo");
+        assertThat(any.getElementsByTagNameNS("foo", "RsdntSts").getLength()).isEqualTo(1);
+    }
+
+    /** No-namespace wildcard content must be captured too (#39). */
+    @Test
+    void capturesNoNamespaceSupplementaryData() throws IOException {
+        MxPacs00200108 mx =
+                MxPacs00200108.parse(Lib.readResource("issues/11/samplemsg.002.001.08-SplmtryData_no_prefix.xml"));
+
+        Element any = (Element) envelope(mx).getAny();
+        assertThat(any).isNotNull();
+        assertThat(any.getLocalName()).isEqualTo("InstrForCdtrAcct");
+    }
+
+    /** Namespaced signature envelope in the header must be captured (#43). */
+    @Test
+    void capturesSignatureEnvelope() throws IOException {
+        MxPacs00200108 mx =
+                MxPacs00200108.parse(Lib.readResource("issues/11/samplemsg.002.001.08-SplmtryData_with_namespace.xml"));
+
+        BusinessAppHdrV01 h = (BusinessAppHdrV01) mx.getAppHdr();
+        Element sgntr = (Element) h.getSgntr().getAny();
+        assertThat(sgntr).isNotNull();
+        assertThat(sgntr.getLocalName()).isEqualTo("Signature");
+        assertThat(sgntr.getNamespaceURI()).isEqualTo("http://www.w3.org/2000/09/xmldsig#");
+    }
+
+    /** XML -> model -> XML round-trip preserves the wildcard payload. */
+    @Test
+    void xmlRoundTripPreservesWildcard() throws IOException {
+        MxPacs00200108 mx =
+                MxPacs00200108.parse(Lib.readResource("issues/11/samplemsg.002.001.08-SplmtryData_with_namespace.xml"));
+
+        String xml = mx.message();
+        assertThat(xml).contains("InstrForCdtrAcct").contains("RsdntSts").contains("foo");
+    }
+
+    /** toJson emits the wildcard content (not {}), and fromJson restores it as a DOM Element. */
+    @Test
+    void jsonRoundTripPreservesWildcard() throws IOException {
+        MxPacs00200108 mx =
+                MxPacs00200108.parse(Lib.readResource("issues/11/samplemsg.002.001.08-SplmtryData_with_namespace.xml"));
+
+        String json = mx.toJson();
+        assertThat(json).contains("InstrForCdtrAcct");
+        assertThat(json).doesNotContain("\"any\": {}");
+
+        MxPacs00200108 restored = MxPacs00200108.fromJson(json);
+        Element any = (Element) envelope(restored).getAny();
+        assertThat(any).isNotNull();
+        assertThat(any.getLocalName()).isEqualTo("InstrForCdtrAcct");
+
+        // the restored Element must re-marshal back to XML (a String would be escaped, not an element)
+        assertThat(restored.message()).contains("InstrForCdtrAcct").contains("RsdntSts");
+    }
+
+    private static SupplementaryDataEnvelope1 envelope(MxPacs00200108 mx) {
+        return mx.getFIToFIPmtStsRpt()
+                .getTxInfAndSts()
+                .get(0)
+                .getSplmtryData()
+                .get(0)
+                .getEnvlp();
+    }
+}

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/ElementJsonAdapterTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/ElementJsonAdapterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2006-2026 Prowide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.prowidesoftware.swift.model.mx.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.reflect.TypeToken;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+
+class ElementJsonAdapterTest {
+
+    private final ElementJsonAdapter adapter = new ElementJsonAdapter();
+
+    @Test
+    void serializesElementAsRawXmlString() {
+        Element element = ElementJsonAdapter.toElement(
+                "<TEST:TestData xmlns:TEST=\"appian:test:smm\">" + "<TEST:tag>Hello World!</TEST:tag></TEST:TestData>");
+
+        JsonPrimitive json = (JsonPrimitive) adapter.serialize(element, null, null);
+        assertThat(json.getAsString())
+                .contains("TestData")
+                .contains("Hello World!")
+                .doesNotContain("<?xml");
+    }
+
+    @Test
+    void deserializesRawXmlStringIntoNamespaceAwareElement() {
+        Element element =
+                adapter.deserialize(new JsonPrimitive("<a:Foo xmlns:a=\"urn:x\"><a:Bar>v</a:Bar></a:Foo>"), null, null);
+
+        assertThat(element).isNotNull();
+        assertThat(element.getLocalName()).isEqualTo("Foo");
+        assertThat(element.getNamespaceURI()).isEqualTo("urn:x");
+        assertThat(element.getElementsByTagNameNS("urn:x", "Bar").getLength()).isEqualTo(1);
+    }
+
+    @Test
+    void handlesNullAndBlank() {
+        assertThat(adapter.serialize(null, null, null)).isEqualTo(JsonNull.INSTANCE);
+        assertThat(adapter.deserialize(JsonNull.INSTANCE, null, null)).isNull();
+        assertThat(adapter.deserialize(new JsonPrimitive("   "), null, null)).isNull();
+        assertThat(ElementJsonAdapter.toElement(null)).isNull();
+    }
+
+    /**
+     * SwAny (#41) holds a {@code List<Element>}: with the type hierarchy adapter registered, the list
+     * serializes to an array of XML strings and deserializes back to a list of DOM Elements.
+     */
+    @Test
+    void listOfElementsRoundTrips() {
+        Gson gson = new GsonBuilder()
+                .registerTypeHierarchyAdapter(Element.class, adapter)
+                .create();
+        List<Element> list = List.of(
+                ElementJsonAdapter.toElement("<a:One xmlns:a=\"urn:x\"/>"),
+                ElementJsonAdapter.toElement("<a:Two xmlns:a=\"urn:x\"/>"));
+
+        String json = gson.toJson(list);
+        assertThat(json).contains("One").contains("Two");
+
+        List<Element> restored = gson.fromJson(json, new TypeToken<List<Element>>() {}.getType());
+        assertThat(restored).hasSize(2);
+        assertThat(restored.get(0).getLocalName()).isEqualTo("One");
+        assertThat(restored.get(1).getLocalName()).isEqualTo("Two");
+    }
+}


### PR DESCRIPTION
## Problem

`xsd:any` wildcard content — most commonly `SplmtryData/Envlp` payloads, also `Sgntr` signature envelopes and `SwAny` child elements — was silently dropped when parsing MX messages. After `AbstractMX.parse(...)` the `@XmlAnyElement` field was `null`, and `toJson()` rendered it as `"envelope": {}`.

Customer ref **PWUS-18** (camt.056.001.08 SupplementaryData); GitHub issues **#39** (admi.007), **#43** (signature envelope). #41 (SwAny) is addressed for element content — see note below.

## Root cause

- **Read side:** `NamespaceAndElementFilter` skipped any subtree whose namespace wasn't the main message namespace or a SWIFT `xsys` namespace, dropping wildcard content before it reached JAXB. Naively forwarding it crashed JAXB's `UnmarshallingContext` with a negative-index error, because `startPrefixMapping` was selectively forwarded while `endPrefixMapping` was not (unbalanced namespace stack).
- **Write side:** no Gson adapter for `org.w3c.dom.Element`, so the DOM node serialized to `{}`.

## Changes (all in `iso20022-core`, no generated code touched)

**Read side — `NamespaceAndElementFilter`**
- Forward foreign / no-namespace wildcard subtrees to JAXB verbatim (namespaces intact) so `@XmlAnyElement` materializes them as `org.w3c.dom.Element`.
- Balanced prefix-mapping handling: buffer `startPrefixMapping`, synthesize matching ends from a per-element stack, and override `endPrefixMapping` to a no-op — eliminating the negative-index crash.
- Drop the prefix from the qName when unbinding the main namespace, so wildcard content reusing the main namespace no longer fails DOM construction.

**Write side**
- New `ElementJsonAdapter` serializes `Element` as raw XML (registered via `registerTypeHierarchyAdapter` so concrete DOM impls match), fixing the `{}` output.
- New `WildcardElementRepair` restores `@XmlAnyElement` string values back into DOM Elements after `fromJson`, so an XML round-trip survives a JSON round-trip.

## Tests

- Per-issue `Issue39`, `Issue41`, `Issue43` using the reported payloads; re-enabled `Issue11`.
- `WildcardAnyParsingTest` — capture (foreign-ns, no-ns, signature), XML round-trip, and JSON round-trip, including the **exact PWUS-18 camt.056.001.08** scenario.
- `ElementJsonAdapterTest` and a prefix-mapping balance guard in `NamespaceAndElementFilterTest`.
- Added `model-admi` as a test dependency (for #39's admi.007 payload).
- Full `iso20022-core` suite: 365 tests, 0 failures.

## Note on #41 (SwAny)

The reported payload `<Sw:ThirdPartyRefusalReason>ABCD</...>` is plain text, but `SwAny` is generated from an element-only `xsd:any` (`@XmlAnyElement List<Element>`), so bare text is schema-invalid and cannot bind — `getAny()` correctly stays empty. Child-element content (the valid usage, previously dropped) is now captured. Both behaviors are documented as `Issue41` test methods.
