### PR TITLE
(PW-3405) Configurable fallback zone for date time and time elements without offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Prowide ISO 20022 - CHANGELOG
 
+### 10.3.11 - SNAPSHOT
+  * (PW-3405) Feat: Configurable fallback zone for date time and time elements without offset (new adapter constructors and TypeAdaptersConfiguration.withFallbackZone); time elements now resolve the daylight-saving aware offset
+
 ### 10.3.10 - July 2026
   * (PW-3251) Feat: lenient parsing of file-format (FileAct) payloads with sibling `AppHdr` and `Document` root elements or undeclared namespace prefixes, applied consistently across all parsing entry points without copying the payload
   * (PW-3251) `MxParseUtils.identifyMessage` now returns an empty Optional on blank input instead of throwing an IllegalArgumentException

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/adapters/TypeAdaptersConfiguration.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/adapters/TypeAdaptersConfiguration.java
@@ -16,6 +16,7 @@
 package com.prowidesoftware.swift.model.mx.adapters;
 
 import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -117,6 +118,26 @@ public class TypeAdaptersConfiguration {
             this.yearAdapter = other.yearAdapter;
             this.monthAdapter = other.monthAdapter;
         }
+    }
+
+    /**
+     * Creates a configuration with the default adapters, where date time and time values without offset in the XML
+     * are resolved in the given zone instead of the JVM default time zone.
+     * <p>
+     * Use this to make the parsing of offset-less (local) values independent of the server configuration, for
+     * example with {@link java.time.ZoneOffset#UTC}. Values with an explicit offset in the XML are not affected.
+     *
+     * @param fallbackZone zone used to resolve date time and time values without offset
+     * @return a new configuration with the default adapters using the given fallback zone
+     * @see OffsetDateTimeAdapter#OffsetDateTimeAdapter(ZoneId)
+     * @see OffsetTimeAdapter#OffsetTimeAdapter(ZoneId)
+     * @since 10.3.11
+     */
+    public static TypeAdaptersConfiguration withFallbackZone(ZoneId fallbackZone) {
+        TypeAdaptersConfiguration conf = new TypeAdaptersConfiguration();
+        conf.dateTimeAdapter = new IsoDateTimeAdapter(new OffsetDateTimeAdapter(fallbackZone));
+        conf.timeAdapter = new IsoTimeAdapter(new OffsetTimeAdapter(fallbackZone));
+        return conf;
     }
 
     /**

--- a/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/adapters/ZuluOffsetDateTimeAdapter.java
+++ b/iso20022-core/src/main/java/com/prowidesoftware/swift/model/mx/adapters/ZuluOffsetDateTimeAdapter.java
@@ -24,6 +24,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -38,6 +39,9 @@ import java.util.regex.Pattern;
  * <p>
  * Notice the configured adapter in the model is the {@link IsoDateTimeAdapter} wrapper class, but you can pass this
  * default implementation or your own in the constructor.
+ * <p>
+ * Date time values without offset in the XML are resolved in a fallback zone, by default the JVM default time zone.
+ * Use {@link #ZuluOffsetDateTimeAdapter(ZoneId)} to set a specific zone.
  *
  * @see TypeAdaptersConfiguration
  * @since 9.4.5
@@ -48,11 +52,28 @@ public class ZuluOffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime
     private static final Pattern FRACTIONAL_SECONDS_PATTERN = Pattern.compile(FRACTIONAL_SECONDS_REGEX);
 
     private final DateTimeFormatter marshalFormat;
+    private final ZoneId fallbackZone;
 
     /**
-     * Creates a date time adapter with the default format.
+     * Creates a date time adapter with the default format, resolving values without offset in the JVM default zone
+     *
+     * @see #ZuluOffsetDateTimeAdapter(ZoneId)
      */
     public ZuluOffsetDateTimeAdapter() {
+        this(ZoneId.systemDefault());
+    }
+
+    /**
+     * Creates a date time adapter with the default format and a specific fallback zone for values without offset.
+     * <p>
+     * A date time without offset in the XML is a valid xs:dateTime lexical form meaning local time with indeterminate
+     * zone. The fallback zone is used to resolve the offset of these values when unmarshalling, applying the zone
+     * rules in effect at the parsed date time. Values with an explicit offset in the XML are not affected.
+     *
+     * @param fallbackZone zone used to resolve date time values without offset, for example {@link ZoneOffset#UTC}
+     * @since 10.3.11
+     */
+    public ZuluOffsetDateTimeAdapter(ZoneId fallbackZone) {
         this.marshalFormat = new DateTimeFormatterBuilder()
                 .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
                 .optionalStart()
@@ -61,6 +82,7 @@ public class ZuluOffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime
                 .appendPattern("'Z'")
                 .toFormatter()
                 .withZone(ZoneOffset.UTC);
+        this.fallbackZone = Objects.requireNonNull(fallbackZone, "fallback zone must not be null");
     }
 
     /**
@@ -71,7 +93,7 @@ public class ZuluOffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime
      */
     @Override
     public OffsetDateTime unmarshal(String value) {
-        return parseOffsetDateTime(value);
+        return parseOffsetDateTime(value, this.fallbackZone);
     }
 
     /**
@@ -96,7 +118,7 @@ public class ZuluOffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime
         return formatted;
     }
 
-    private static OffsetDateTime parseOffsetDateTime(String value) {
+    private static OffsetDateTime parseOffsetDateTime(String value, ZoneId fallbackZone) {
         if (value == null) {
             return null;
         }
@@ -105,9 +127,9 @@ public class ZuluOffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime
         } catch (DateTimeParseException e) {
             log.log(Level.FINEST, "Error parsing OffsetDateTime: " + e.getMessage());
             try {
-                // Attempt to parse as LocalDateTime and assume system default time zone
+                // Attempt to parse as LocalDateTime without offset, resolved in the fallback zone
                 LocalDateTime localDateTime = LocalDateTime.parse(value);
-                return localDateTime.atZone(ZoneId.systemDefault()).toOffsetDateTime();
+                return localDateTime.atZone(fallbackZone).toOffsetDateTime();
             } catch (DateTimeParseException e2) {
                 log.log(Level.FINEST, "Error parsing LocalDateTime: " + e2.getMessage());
                 return null;

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/OffsetDateTimeAdapterTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/OffsetDateTimeAdapterTest.java
@@ -1,8 +1,10 @@
 package com.prowidesoftware.swift.model.mx.adapters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.*;
+import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Test;
 
 class OffsetDateTimeAdapterTest {
@@ -89,5 +91,62 @@ class OffsetDateTimeAdapterTest {
         testDateTimeImpl("2018-01-15T17:30:33.000000001Z", "2018-01-15T17:30:33.000000001+00:00");
         testDateTimeImpl("2018-01-15T17:30:33.123456789Z", "2018-01-15T17:30:33.123456789+00:00");
         testDateTimeImpl("2018-01-15T17:30:33Z", "2018-01-15T17:30:33+00:00");
+    }
+
+    @Test
+    void testFallbackZoneAppliedToValuesWithoutOffset() throws Exception {
+        // fixed offset zone
+        OffsetDateTimeAdapter utc = new OffsetDateTimeAdapter(ZoneOffset.UTC);
+        assertEquals(OffsetDateTime.parse("2021-09-19T12:13:14Z"), utc.unmarshal("2021-09-19T12:13:14"));
+        assertEquals("2021-09-19T12:13:14+00:00", utc.marshal(utc.unmarshal("2021-09-19T12:13:14")));
+
+        // region zone without daylight saving
+        OffsetDateTimeAdapter kolkata = new OffsetDateTimeAdapter(ZoneId.of("Asia/Kolkata"));
+        assertEquals(
+                ZoneOffset.ofHoursMinutes(5, 30),
+                kolkata.unmarshal("2021-09-19T12:13:14").getOffset());
+
+        // region zone with daylight saving: the offset in effect at the parsed date time is applied, not the one now
+        OffsetDateTimeAdapter berlin = new OffsetDateTimeAdapter(ZoneId.of("Europe/Berlin"));
+        OffsetDateTime summer = berlin.unmarshal("2026-06-29T12:30:00");
+        assertEquals(ZoneOffset.ofHours(2), summer.getOffset());
+        assertEquals(LocalDateTime.parse("2026-06-29T12:30:00"), summer.toLocalDateTime());
+        assertEquals(
+                ZoneOffset.ofHours(1), berlin.unmarshal("2026-01-29T12:30:00").getOffset());
+    }
+
+    @Test
+    void testFallbackZoneIgnoredForValuesWithOffset() throws Exception {
+        OffsetDateTimeAdapter utc = new OffsetDateTimeAdapter(ZoneOffset.UTC);
+        assertEquals(OffsetDateTime.parse("2021-09-19T12:13:14+08:30"), utc.unmarshal("2021-09-19T12:13:14+08:30"));
+        assertEquals(
+                OffsetDateTime.parse("2021-09-19T12:13:14.123-03:00"), utc.unmarshal("2021-09-19T12:13:14.123-03:00"));
+        assertEquals(OffsetDateTime.parse("2021-09-19T12:13:14Z"), utc.unmarshal("2021-09-19T12:13:14Z"));
+    }
+
+    @Test
+    void testFallbackZoneWithCustomFormat() throws Exception {
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss[XXX]");
+        OffsetDateTimeAdapter adapter = new OffsetDateTimeAdapter(format, ZoneOffset.ofHours(-3));
+        assertEquals(
+                ZoneOffset.ofHours(-3), adapter.unmarshal("2021-09-19T12:13:14").getOffset());
+        assertEquals(
+                ZoneOffset.ofHours(1),
+                adapter.unmarshal("2021-09-19T12:13:14+01:00").getOffset());
+    }
+
+    @Test
+    void testDefaultFallbackIsSystemDefaultZone() throws Exception {
+        OffsetDateTime parsed = new OffsetDateTimeAdapter().unmarshal("2021-09-19T12:13:14");
+        LocalDateTime local = LocalDateTime.parse("2021-09-19T12:13:14");
+        assertEquals(ZoneId.systemDefault().getRules().getOffset(local), parsed.getOffset());
+        assertEquals(local, parsed.toLocalDateTime());
+    }
+
+    @Test
+    void testNullFallbackZoneRejected() {
+        assertThrows(NullPointerException.class, () -> new OffsetDateTimeAdapter((ZoneId) null));
+        assertThrows(
+                NullPointerException.class, () -> new OffsetDateTimeAdapter(DateTimeFormatter.ISO_DATE_TIME, null));
     }
 }

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/OffsetTimeAdapterTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/OffsetTimeAdapterTest.java
@@ -16,6 +16,7 @@
 package com.prowidesoftware.swift.model.mx.adapters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.*;
 import java.time.format.DateTimeFormatter;
@@ -47,7 +48,7 @@ public class OffsetTimeAdapterTest {
     @Test
     public void testUnmarshallNoOffset() throws Exception {
         OffsetTime systemDateTime = OffsetTime.parse(
-                "12:50:08" + ZoneOffset.systemDefault().getRules().getStandardOffset(Instant.now()));
+                "12:50:08" + ZoneOffset.systemDefault().getRules().getOffset(Instant.now()));
         OffsetTime offsetTime = adapter.unmarshal("12:50:08");
         assertEquals(12, offsetTime.getHour());
         assertEquals(50, offsetTime.getMinute());
@@ -147,11 +148,54 @@ public class OffsetTimeAdapterTest {
     }
 
     private static String systemOffset() {
-        ZoneOffset zoneOffset = ZoneId.systemDefault().getRules().getStandardOffset(Instant.now());
+        ZoneOffset zoneOffset = ZoneId.systemDefault().getRules().getOffset(Instant.now());
         String offset = zoneOffset.toString();
         if (offset.equals("Z")) {
             offset = "+00:00";
         }
         return offset;
+    }
+
+    @Test
+    public void testFallbackZoneAppliedToValuesWithoutOffset() throws Exception {
+        // fixed offset zone
+        OffsetTimeAdapter utc = new OffsetTimeAdapter(ZoneOffset.UTC);
+        assertEquals(OffsetTime.parse("12:50:08Z"), utc.unmarshal("12:50:08"));
+        assertEquals("12:50:08+00:00", utc.marshal(utc.unmarshal("12:50:08")));
+
+        // region zone without daylight saving
+        OffsetTimeAdapter kolkata = new OffsetTimeAdapter(ZoneId.of("Asia/Kolkata"));
+        assertEquals(
+                ZoneOffset.ofHoursMinutes(5, 30), kolkata.unmarshal("12:50:08").getOffset());
+        assertEquals(LocalTime.parse("12:50:08"), kolkata.unmarshal("12:50:08").toLocalTime());
+
+        // region zone with daylight saving: a time has no date, the offset in effect now is applied (not the standard
+        // offset, that would be one hour off during summer time)
+        ZoneId berlin = ZoneId.of("Europe/Berlin");
+        assertEquals(
+                berlin.getRules().getOffset(Instant.now()),
+                new OffsetTimeAdapter(berlin).unmarshal("12:50:08").getOffset());
+    }
+
+    @Test
+    public void testFallbackZoneIgnoredForValuesWithOffset() throws Exception {
+        OffsetTimeAdapter utc = new OffsetTimeAdapter(ZoneOffset.UTC);
+        assertEquals(
+                ZoneOffset.of("-03:00"), utc.unmarshal("12:50:08.123-03:00").getOffset());
+        assertEquals(ZoneOffset.of("+08:30"), utc.unmarshal("12:50:08+08:30").getOffset());
+    }
+
+    @Test
+    public void testFallbackZoneWithCustomFormat() throws Exception {
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("HH:mm:ss[XXX]");
+        OffsetTimeAdapter adapter = new OffsetTimeAdapter(format, ZoneOffset.ofHours(-3));
+        assertEquals(ZoneOffset.ofHours(-3), adapter.unmarshal("12:50:08").getOffset());
+        assertEquals(ZoneOffset.ofHours(1), adapter.unmarshal("12:50:08+01:00").getOffset());
+    }
+
+    @Test
+    public void testNullFallbackZoneRejected() {
+        assertThrows(NullPointerException.class, () -> new OffsetTimeAdapter((ZoneId) null));
+        assertThrows(NullPointerException.class, () -> new OffsetTimeAdapter(DateTimeFormatter.ISO_TIME, null));
     }
 }

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/TypeAdaptersConfigurationFallbackZoneTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/TypeAdaptersConfigurationFallbackZoneTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2006-2023 Prowide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.prowidesoftware.swift.model.mx.adapters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.prowidesoftware.swift.model.mx.MxPacs00800102;
+import com.prowidesoftware.swift.model.mx.MxReadConfiguration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End to end test of the fallback zone option for date time and time elements without offset, injected through the
+ * read configuration.
+ */
+public class TypeAdaptersConfigurationFallbackZoneTest {
+
+    private static final String XML_WITHOUT_OFFSET =
+            "<Document xmlns=\"urn:iso:std:iso:20022:tech:xsd:pacs.008.001.02\">"
+                    + "<FIToFICstmrCdtTrf>"
+                    + "<GrpHdr>"
+                    + "<MsgId>TEST</MsgId>"
+                    + "<CreDtTm>2021-10-19T12:13:14</CreDtTm>"
+                    + "<NbOfTxs>1</NbOfTxs>"
+                    + "<SttlmInf><SttlmMtd>INDA</SttlmMtd></SttlmInf>"
+                    + "</GrpHdr>"
+                    + "<CdtTrfTxInf>"
+                    + "<PmtId><EndToEndId>E2E</EndToEndId><TxId>TX</TxId></PmtId>"
+                    + "<IntrBkSttlmAmt Ccy=\"EUR\">100</IntrBkSttlmAmt>"
+                    + "<SttlmTmReq><CLSTm>12:13:14</CLSTm></SttlmTmReq>"
+                    + "</CdtTrfTxInf>"
+                    + "</FIToFICstmrCdtTrf>"
+                    + "</Document>";
+
+    private static final String XML_WITH_OFFSET = XML_WITHOUT_OFFSET.replace("12:13:14<", "12:13:14-03:00<");
+
+    private static MxReadConfiguration confWithFallbackZone(ZoneId zone) {
+        MxReadConfiguration conf = new MxReadConfiguration();
+        conf.adapters = TypeAdaptersConfiguration.withFallbackZone(zone);
+        return conf;
+    }
+
+    @Test
+    public void testFallbackZoneAppliedOnParse() {
+        MxPacs00800102 mx = MxPacs00800102.parse(XML_WITHOUT_OFFSET, confWithFallbackZone(ZoneId.of("Asia/Kolkata")));
+
+        OffsetDateTime creDtTm = mx.getFIToFICstmrCdtTrf().getGrpHdr().getCreDtTm();
+        assertEquals(LocalDateTime.parse("2021-10-19T12:13:14"), creDtTm.toLocalDateTime());
+        assertEquals(ZoneOffset.ofHoursMinutes(5, 30), creDtTm.getOffset());
+
+        OffsetTime clsTm = mx.getFIToFICstmrCdtTrf()
+                .getCdtTrfTxInf()
+                .get(0)
+                .getSttlmTmReq()
+                .getCLSTm();
+        assertEquals(LocalTime.parse("12:13:14"), clsTm.toLocalTime());
+        assertEquals(ZoneOffset.ofHoursMinutes(5, 30), clsTm.getOffset());
+
+        // the resolved offset is then explicit in the serialization
+        String xml = mx.message();
+        assertTrue(xml.contains("2021-10-19T12:13:14+05:30"), xml);
+        assertTrue(xml.contains(">12:13:14+05:30<"), xml);
+    }
+
+    @Test
+    public void testFallbackZoneUtcIsIndependentOfSystemDefault() {
+        MxPacs00800102 mx = MxPacs00800102.parse(XML_WITHOUT_OFFSET, confWithFallbackZone(ZoneOffset.UTC));
+        assertEquals(
+                OffsetDateTime.parse("2021-10-19T12:13:14Z"),
+                mx.getFIToFICstmrCdtTrf().getGrpHdr().getCreDtTm());
+        assertEquals(
+                OffsetTime.parse("12:13:14Z"),
+                mx.getFIToFICstmrCdtTrf()
+                        .getCdtTrfTxInf()
+                        .get(0)
+                        .getSttlmTmReq()
+                        .getCLSTm());
+    }
+
+    @Test
+    public void testFallbackZoneDoesNotAffectValuesWithOffset() {
+        MxPacs00800102 mx = MxPacs00800102.parse(XML_WITH_OFFSET, confWithFallbackZone(ZoneOffset.UTC));
+        assertEquals(
+                OffsetDateTime.parse("2021-10-19T12:13:14-03:00"),
+                mx.getFIToFICstmrCdtTrf().getGrpHdr().getCreDtTm());
+        assertEquals(
+                OffsetTime.parse("12:13:14-03:00"),
+                mx.getFIToFICstmrCdtTrf()
+                        .getCdtTrfTxInf()
+                        .get(0)
+                        .getSttlmTmReq()
+                        .getCLSTm());
+    }
+
+    @Test
+    public void testDefaultConfigurationKeepsSystemDefaultZone() {
+        MxPacs00800102 mx = MxPacs00800102.parse(XML_WITHOUT_OFFSET);
+        LocalDateTime local = LocalDateTime.parse("2021-10-19T12:13:14");
+        OffsetDateTime creDtTm = mx.getFIToFICstmrCdtTrf().getGrpHdr().getCreDtTm();
+        assertEquals(local, creDtTm.toLocalDateTime());
+        assertEquals(ZoneId.systemDefault().getRules().getOffset(local), creDtTm.getOffset());
+    }
+}

--- a/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/ZuluOffsetDateTimeAdapterUnmarshallingTest.java
+++ b/iso20022-core/src/test/java/com/prowidesoftware/swift/model/mx/adapters/ZuluOffsetDateTimeAdapterUnmarshallingTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Month;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.Test;
 
 public class ZuluOffsetDateTimeAdapterUnmarshallingTest {
@@ -87,5 +89,33 @@ public class ZuluOffsetDateTimeAdapterUnmarshallingTest {
         assertEquals(50, datetime.getMinute());
         assertEquals(8, datetime.getSecond());
         assertEquals(0, datetime.getNano());
+    }
+
+    @Test
+    public void testUnmarshallNoOffsetWithFallbackZone() {
+        String value = "2022-03-04T12:50:08";
+        assertEquals(
+                0,
+                new ZuluOffsetDateTimeAdapter(ZoneOffset.UTC)
+                        .unmarshal(value)
+                        .getOffset()
+                        .getTotalSeconds());
+        assertEquals(
+                19800,
+                new ZuluOffsetDateTimeAdapter(ZoneId.of("Asia/Kolkata"))
+                        .unmarshal(value)
+                        .getOffset()
+                        .getTotalSeconds());
+
+        // zone with daylight saving: the offset in effect at the parsed date time is applied
+        ZuluOffsetDateTimeAdapter berlin = new ZuluOffsetDateTimeAdapter(ZoneId.of("Europe/Berlin"));
+        assertEquals(3600, berlin.unmarshal("2022-03-04T12:50:08").getOffset().getTotalSeconds());
+        assertEquals(7200, berlin.unmarshal("2022-07-04T12:50:08").getOffset().getTotalSeconds());
+        assertEquals(12, berlin.unmarshal("2022-07-04T12:50:08").getHour());
+
+        // values with offset are not affected
+        assertEquals(
+                -10800,
+                berlin.unmarshal("2022-07-04T12:50:08-03:00").getOffset().getTotalSeconds());
     }
 }

--- a/model-common-types/src/main/java/com/prowidesoftware/swift/model/mx/adapters/OffsetDateTimeAdapter.java
+++ b/model-common-types/src/main/java/com/prowidesoftware/swift/model/mx/adapters/OffsetDateTimeAdapter.java
@@ -20,10 +20,10 @@ import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.time.format.DateTimeFormatterBuilder;
@@ -33,6 +33,9 @@ import java.util.regex.Pattern;
 /**
  * Default generic adapter to use when non is provided via the configuration API.
  * Used as default implementation for the {@link IsoDateTimeAdapter}.
+ * <p>
+ * Date time values without offset in the XML are resolved in a fallback zone, by default the JVM default time zone.
+ * Use {@link #OffsetDateTimeAdapter(ZoneId)} to set a specific zone.
  *
  * @since 10.0.0
  */
@@ -41,6 +44,7 @@ public class OffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime> {
     private final DateTimeFormatter marshalFormat;
     private final DateTimeFormatter unmarshalFormat;
     private final XmlAdapter<String, OffsetDateTime> customAdapterImpl;
+    private final ZoneId fallbackZone;
     //private final String regex = "\\\\.0{1,}[Z+-]";
     // Regex to capture three digits after a dot, representing milliseconds
     // The (?:\\d{3}) part makes the group non-capturing, but the \\d{3} matches the digits.
@@ -52,9 +56,27 @@ public class OffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime> {
     int maxPrecision = 9;
 
     /**
-     * Creates a date time adapter with the default format
+     * Creates a date time adapter with the default format, resolving values without offset in the JVM default zone
+     *
+     * @see #OffsetDateTimeAdapter(ZoneId)
      */
     public OffsetDateTimeAdapter() {
+        this(ZoneId.systemDefault());
+    }
+
+    /**
+     * Creates a date time adapter with the default format and a specific fallback zone for values without offset.
+     * <p>
+     * A date time without offset in the XML is a valid xs:dateTime lexical form meaning local time with indeterminate
+     * zone, and it cannot be represented as such by an {@link OffsetDateTime}. The fallback zone is used to resolve
+     * the offset of these values when unmarshalling, applying the zone rules in effect at the parsed date time.
+     * Values with an explicit offset in the XML are not affected.
+     *
+     * @param fallbackZone zone used to resolve date time values without offset, for example
+     *                     {@link java.time.ZoneOffset#UTC} to make the result independent of the JVM configuration
+     * @since 10.3.11
+     */
+    public OffsetDateTimeAdapter(ZoneId fallbackZone) {
         this.marshalFormat = new DateTimeFormatterBuilder()
                 .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
                 .optionalStart()
@@ -66,15 +88,33 @@ public class OffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime> {
                 .toFormatter();
         this.unmarshalFormat = this.marshalFormat;
         this.customAdapterImpl = null;
+        this.fallbackZone = Objects.requireNonNull(fallbackZone, "fallback zone must not be null");
     }
 
     /**
-     * Creates a time adapter with a specific given format that will be used for both the marshalling and unmarshalling
+     * Creates a time adapter with a specific given format that will be used for both the marshalling and unmarshalling,
+     * resolving values without offset in the JVM default zone
+     *
+     * @see #OffsetDateTimeAdapter(DateTimeFormatter, ZoneId)
      */
     public OffsetDateTimeAdapter(DateTimeFormatter dateFormat) {
+        this(dateFormat, ZoneId.systemDefault());
+    }
+
+    /**
+     * Creates a time adapter with a specific given format that will be used for both the marshalling and unmarshalling,
+     * and a specific fallback zone for values without offset
+     *
+     * @param dateFormat format for both the marshalling and unmarshalling
+     * @param fallbackZone zone used to resolve date time values without offset
+     * @see #OffsetDateTimeAdapter(ZoneId)
+     * @since 10.3.11
+     */
+    public OffsetDateTimeAdapter(DateTimeFormatter dateFormat, ZoneId fallbackZone) {
         this.marshalFormat = dateFormat;
         this.unmarshalFormat = dateFormat;
         this.customAdapterImpl = null;
+        this.fallbackZone = Objects.requireNonNull(fallbackZone, "fallback zone must not be null");
     }
 
     /**
@@ -84,6 +124,8 @@ public class OffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime> {
         this.marshalFormat = null;
         this.unmarshalFormat = null;
         this.customAdapterImpl = customAdapterImpl;
+        // not used, the custom implementation decides how to handle values without offset
+        this.fallbackZone = null;
     }
 
     /**
@@ -97,7 +139,7 @@ public class OffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime> {
         if (this.customAdapterImpl != null) {
             return this.customAdapterImpl.unmarshal(value);
         } else {
-            return parseZonedDateTime(this.unmarshalFormat, value);
+            return parseZonedDateTime(this.unmarshalFormat, value, this.fallbackZone);
         }
     }
 
@@ -132,7 +174,7 @@ public class OffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime> {
     }
 
 
-    static OffsetDateTime parseZonedDateTime(DateTimeFormatter dateTimeFormatter, String value) {
+    static OffsetDateTime parseZonedDateTime(DateTimeFormatter dateTimeFormatter, String value, ZoneId fallbackZone) {
         if (value == null) {
             return null;
         }
@@ -143,11 +185,11 @@ public class OffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime> {
             if (log.isLoggable(Level.FINEST)) {
                 log.finest("Error parsing to OffsetDateTime: " + e.getMessage());
             }
-            ZoneId zoneId = ZoneOffset.systemDefault();
-            OffsetDateTime dateTime = LocalDateTime.parse(value, dateTimeFormatter)
-                    .atZone(zoneId)
+            // no offset in the source: resolve the local date time in the fallback zone, applying the zone rules
+            // in effect at that date time (daylight saving aware)
+            return LocalDateTime.parse(value, dateTimeFormatter)
+                    .atZone(fallbackZone)
                     .toOffsetDateTime();
-            return dateTime;
         }
     }
 

--- a/model-common-types/src/main/java/com/prowidesoftware/swift/model/mx/adapters/OffsetTimeAdapter.java
+++ b/model-common-types/src/main/java/com/prowidesoftware/swift/model/mx/adapters/OffsetTimeAdapter.java
@@ -22,31 +22,50 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Default generic adapter to use when non is provided via the configuration API.
  * Used as default implementation for the {@link IsoTimeAdapter}.
+ * <p>
+ * Time values without offset in the XML are resolved in a fallback zone, by default the JVM default time zone.
+ * Use {@link #OffsetTimeAdapter(ZoneId)} to set a specific zone.
  *
  * @since 10.0.0
  */
 public class OffsetTimeAdapter extends XmlAdapter<String, OffsetTime> {
-    private static final Logger log = Logger.getLogger(OffsetTime.class.getName());
+    private static final Logger log = Logger.getLogger(OffsetTimeAdapter.class.getName());
     private final DateTimeFormatter marshalFormat;
     private final DateTimeFormatter unmarshalFormat;
     private final XmlAdapter<String, OffsetTime> customAdapterImpl;
-    private final String regex = "\\\\.0{1,}[Z+-]";
-    private final Pattern pattern = Pattern.compile(regex);
+    private final ZoneId fallbackZone;
     int minPrecision = 0;
     int maxPrecision = 9;
 
     /**
-     * Creates a time adapter with the default format
+     * Creates a time adapter with the default format, resolving values without offset in the JVM default zone
+     *
+     * @see #OffsetTimeAdapter(ZoneId)
      */
     public OffsetTimeAdapter() {
+        this(ZoneId.systemDefault());
+    }
+
+    /**
+     * Creates a time adapter with the default format and a specific fallback zone for values without offset.
+     * <p>
+     * A time without offset in the XML is a valid xs:time lexical form meaning local time with indeterminate zone,
+     * and it cannot be represented as such by an {@link OffsetTime}. The fallback zone is used to resolve the offset
+     * of these values when unmarshalling. Since a time carries no date to resolve daylight saving, the zone offset in
+     * effect at unmarshalling time is applied. Values with an explicit offset in the XML are not affected.
+     *
+     * @param fallbackZone zone used to resolve time values without offset, for example {@link ZoneOffset#UTC} to make
+     *                     the result independent of the JVM configuration
+     * @since 10.3.11
+     */
+    public OffsetTimeAdapter(ZoneId fallbackZone) {
         this.marshalFormat = new DateTimeFormatterBuilder()
                 .appendPattern("HH:mm:ss")
                 .optionalStart()
@@ -58,15 +77,33 @@ public class OffsetTimeAdapter extends XmlAdapter<String, OffsetTime> {
                 .toFormatter();
         this.unmarshalFormat = this.marshalFormat;
         this.customAdapterImpl = null;
+        this.fallbackZone = Objects.requireNonNull(fallbackZone, "fallback zone must not be null");
     }
 
     /**
-     * Creates a time adapter with a specific given format that will be used for both the marshalling and unmarshalling
+     * Creates a time adapter with a specific given format that will be used for both the marshalling and unmarshalling,
+     * resolving values without offset in the JVM default zone
+     *
+     * @see #OffsetTimeAdapter(DateTimeFormatter, ZoneId)
      */
     public OffsetTimeAdapter(DateTimeFormatter dateFormat) {
+        this(dateFormat, ZoneId.systemDefault());
+    }
+
+    /**
+     * Creates a time adapter with a specific given format that will be used for both the marshalling and unmarshalling,
+     * and a specific fallback zone for values without offset
+     *
+     * @param dateFormat format for both the marshalling and unmarshalling
+     * @param fallbackZone zone used to resolve time values without offset
+     * @see #OffsetTimeAdapter(ZoneId)
+     * @since 10.3.11
+     */
+    public OffsetTimeAdapter(DateTimeFormatter dateFormat, ZoneId fallbackZone) {
         this.marshalFormat = dateFormat;
         this.unmarshalFormat = dateFormat;
         this.customAdapterImpl = null;
+        this.fallbackZone = Objects.requireNonNull(fallbackZone, "fallback zone must not be null");
     }
 
     /**
@@ -76,6 +113,8 @@ public class OffsetTimeAdapter extends XmlAdapter<String, OffsetTime> {
         this.marshalFormat = null;
         this.unmarshalFormat = null;
         this.customAdapterImpl = customAdapterImpl;
+        // not used, the custom implementation decides how to handle values without offset
+        this.fallbackZone = null;
     }
 
     /**
@@ -89,7 +128,7 @@ public class OffsetTimeAdapter extends XmlAdapter<String, OffsetTime> {
         if (this.customAdapterImpl != null) {
             return this.customAdapterImpl.unmarshal(value);
         } else {
-            return parseOffsetTime(this.unmarshalFormat, value);
+            return parseOffsetTime(this.unmarshalFormat, value, this.fallbackZone);
         }
     }
 
@@ -109,15 +148,7 @@ public class OffsetTimeAdapter extends XmlAdapter<String, OffsetTime> {
                 formatted = formatOffsetTime(this.marshalFormat, offsetTime);
             }
 
-            //Remove unused nano if it's only zeros
-            final Matcher matcher = pattern.matcher(formatted);
-            if (matcher.find()){
-                formatted = formatted.replace(matcher.group(), "");
-            }
-
             return formatted.replace("Z", "+00:00");
-
-
         }
     }
 
@@ -125,7 +156,7 @@ public class OffsetTimeAdapter extends XmlAdapter<String, OffsetTime> {
         return dateTimeFormatter.format(offsetTime);
     }
 
-    static OffsetTime parseOffsetTime(DateTimeFormatter dateTimeFormatter, String value) {
+    static OffsetTime parseOffsetTime(DateTimeFormatter dateTimeFormatter, String value, ZoneId fallbackZone) {
         if (value == null) {
             return null;
         }
@@ -137,7 +168,9 @@ public class OffsetTimeAdapter extends XmlAdapter<String, OffsetTime> {
             if (log.isLoggable(Level.FINEST)) {
                 log.finest("Error parsing to OffsetTime: " + e.getMessage());
             }
-            ZoneOffset offset = ZoneOffset.systemDefault().getRules().getStandardOffset(Instant.now());
+            // no offset in the source: a time carries no date to resolve daylight saving, so the fallback zone
+            // offset in effect now is applied (not the standard offset, which ignores daylight saving)
+            ZoneOffset offset = fallbackZone.getRules().getOffset(Instant.now());
             offsetTime = LocalTime.parse(value, dateTimeFormatter).atOffset(offset);
         }
         return offsetTime;


### PR DESCRIPTION
## Summary
- New fallback `ZoneId` option on `OffsetDateTimeAdapter`, `OffsetTimeAdapter` and `ZuluOffsetDateTimeAdapter` to resolve XML date time and time values that carry no offset, instead of always using the JVM default zone. Existing constructors keep the current behaviour; no public signature changed.
- `TypeAdaptersConfiguration.withFallbackZone(ZoneId)` configures both adapters in one call, e.g. `conf.adapters = TypeAdaptersConfiguration.withFallbackZone(ZoneOffset.UTC)` on an `MxReadConfiguration`.
- `OffsetTimeAdapter` fixes: the fallback now uses the daylight-saving aware offset of the zone (it used the standard offset, one hour off during summer time in DST zones and inconsistent with the date time adapter); removed a dead fraction-stripping regex that could never match a formatted time; logger registered under the adapter class name.

## Test plan
- [x] New unit tests for the fallback zone on the three adapters: fixed offset, non-DST region, DST region at summer and winter dates, custom format, null rejection
- [x] New end-to-end test parsing a pacs.008 with offset-less `CreDtTm` and `CLSTm` through `MxReadConfiguration`, including serialization of the resolved offset
- [x] `./gradlew :iso20022-core:test` (438 tests) and `:iso20022-core:javadoc` green, spotless check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
