### PR TITLE
(CU-86bbn397k) Report only the published artifact's classpaths to the dependency graph

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,10 +65,17 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
+      # Generates and submits a dependency graph, enabling Dependabot Alerts for the dependencies of the published artifact.
       # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
+      #
+      # Only the main source set's compile and runtime classpaths are reported, which is exactly what ships in the
+      # published jar. Test-only dependencies (testImplementation) and buildscript/plugin dependencies (axion-release,
+      # spotless) are deliberately left out: they never reach library consumers, and reporting them produces Dependabot
+      # alerts (and downstream Vanta findings) for CVEs in build/test tooling that we cannot act on from this repo.
+      # Direct test dependencies are still kept current by Dependabot version updates (dependabot.yml).
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v6
         with:
           cache-provider: basic  # MIT provider; the v6 default 'enhanced' is proprietary and paid for private repos
           dependency-graph-exclude-projects: ':buildSrc'
+          dependency-graph-include-configurations: '(compile|runtime)Classpath'


### PR DESCRIPTION
## Summary
- Restrict the dependency graph submitted to GitHub to `compileClasspath` and `runtimeClasspath`, i.e. what ships in the published jar. Buildscript/plugin dependencies (axion-release → JGit → BouncyCastle, eddsa) and test-only dependencies are no longer reported.
- Closes the 7 open Dependabot alerts (#1-#6, #8): all of them resolve only in the buildscript `classpath` — verified with `./gradlew buildEnvironment` and `./gradlew dependencies` on `main`, none appear in any project configuration. The alerts close on the next dependency submission from `main` after the merge; Vanta clears on its next sync.
- Same mechanism as prowide/prowide-core#350 (merged). Replaces the earlier approach on this branch of force-pinning patched JGit/BouncyCastle versions on the buildscript classpath, which worked but required permanent pin upkeep and is not the standard adopted across the repos.
- No CHANGELOG entry: CI configuration only, no change in the published artifact.

## Test plan
- [ ] `Java CI with Gradle` passes on the PR
- [ ] After merge: the `dependency-submission` job on `main` succeeds and Dependabot alerts #1-#6, #8 show as closed
- [ ] Vanta test "High vulnerabilities identified in packages are addressed (GitHub Repo)" no longer lists prowide-iso20022 findings after the next sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
